### PR TITLE
feat: refresh console UX and portrait pipeline

### DIFF
--- a/app/admin/capabilities.py
+++ b/app/admin/capabilities.py
@@ -32,6 +32,7 @@ _KNOWN_PLUGIN_ROUTES: dict[str, str] = {
     "persona_extract": "/persona",
     "repeater": "/repeater",
     "wxbot": "/channels?adapter=wechat-sdk",
+    "tibo_reset": "/plugins?plugin=tibo_reset",
 }
 
 _WECHAT_ADAPTER_ID = "wechat-sdk"
@@ -255,6 +256,7 @@ async def build_tenant_capabilities(
     capabilities.extend(
         _plugin_capabilities(
             tenant_id=tenant_id,
+            settings=settings,
             plugin_registry=plugin_registry,
             scope_states=scope_states,
             scope_error=scope_error,
@@ -742,9 +744,16 @@ async def _tenant_plugin_scope_states(
     return overrides, ""
 
 
+def _plugin_secret_missing(name: str, settings: Settings) -> bool:
+    if name == "tibo_reset":
+        return not str(getattr(settings, "tibo_reset_api_url", "") or "").strip()
+    return False
+
+
 def _plugin_capabilities(
     *,
     tenant_id: str,
+    settings: Settings,
     plugin_registry: Any | None,
     scope_states: Mapping[str, bool],
     scope_error: str,
@@ -779,6 +788,7 @@ def _plugin_capabilities(
             item["required"] and item["state"] == "blocked" for item in dependencies
         )
         failure = str(failures.get(name) or "").strip()
+        secret_missing = _plugin_secret_missing(name, settings)
         enabled = bool(metadata) and globally_active and tenant_enabled
         available = enabled and not failure and not required_blocked
         if metadata is None:
@@ -793,6 +803,9 @@ def _plugin_capabilities(
         elif not globally_active:
             health = "action_required"
             status_reason = "plugin_not_active"
+        elif secret_missing:
+            health = "action_required"
+            status_reason = "plugin_not_configured"
         elif not tenant_enabled:
             health = "action_required"
             status_reason = "plugin_disabled_for_tenant"
@@ -828,6 +841,7 @@ def _plugin_capabilities(
             globally_active=globally_active,
             tenant_enabled=tenant_enabled,
             failure=failure,
+            secret_missing=secret_missing,
             dependencies=dependencies,
             scope_error=scope_error,
         )
@@ -1002,6 +1016,7 @@ def _plugin_recovery_actions(
     globally_active: bool,
     tenant_enabled: bool,
     failure: str,
+    secret_missing: bool,
     dependencies: list[dict[str, Any]],
     scope_error: str,
 ) -> list[dict[str, Any]]:
@@ -1012,6 +1027,15 @@ def _plugin_recovery_actions(
                 "install",
                 f"安装 {_PLUGIN_LABELS.get(name, name)}",
                 f"/plugins/marketplace?plugin={name}",
+                requires_admin=True,
+            )
+        )
+    elif secret_missing and globally_active:
+        actions.append(
+            _action(
+                "configure",
+                f"配置 {_PLUGIN_LABELS.get(name, name)} 接口地址",
+                f"/plugins?plugin={name}",
                 requires_admin=True,
             )
         )

--- a/app/common/config.py
+++ b/app/common/config.py
@@ -550,8 +550,8 @@ class Settings(BaseSettings):
     )
     wxbot_preview_wait_seconds: float = 30.0
     wxbot_preview_poll_interval_seconds: float = 0.7
-    # Organization-specific polling is inert until both the feature flag and
-    # an explicit feed endpoint are configured by the operator.
+    # Compatibility flag for existing env files. Runtime enablement is
+    # plugin_state; a missing API URL is reported as unconfigured.
     tibo_reset_enabled: bool = False
     tibo_reset_api_url: str = ""
     tibo_reset_poll_interval_seconds: float = Field(default=300.0, ge=30.0)

--- a/app/common/config.py
+++ b/app/common/config.py
@@ -612,6 +612,7 @@ class Settings(BaseSettings):
     speaker_portrait_hot_update_enabled: bool = True
     speaker_portrait_hot_update_min_messages: int = Field(default=40, ge=1)
     speaker_portrait_hot_update_min_seconds: float = Field(default=3600.0, ge=60)
+    speaker_portrait_style_sync_enabled: bool = True
     speaker_portrait_data_dir: str = "/data/portraits"
     speaker_portrait_host_dir: str = "/opt/agent-console-portraits"
     speaker_portrait_inline_max_messages: int = Field(default=400, ge=50)

--- a/app/infra/runtime_schema.py
+++ b/app/infra/runtime_schema.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-RUNTIME_SCHEMA_REVISION = "0049_speaker_portrait_hot_update"
+RUNTIME_SCHEMA_REVISION = "0050_speaker_portrait_cursor"
 RUNTIME_SCHEMA_CONTRACT_NAME = "agent-console-runtime"
 # 0046 adds durable memory-event provenance, evidence, and physical expiry.
 RUNTIME_SCHEMA_COMPATIBILITY_LEVEL = 9
@@ -109,6 +109,7 @@ RUNTIME_SCHEMA_INDEXES = frozenset(
         "idx_local_agent_job_queue_due",
         "idx_local_agent_job_tenant_created",
         "idx_speaker_portrait_job_queue",
+        "idx_speaker_portrait_job_attempt",
         "idx_speaker_portrait_revision_portrait",
         "idx_speaker_portrait_hot_update",
         "ux_speaker_portrait_identity",
@@ -250,6 +251,8 @@ RUNTIME_SCHEMA_COLUMN_CONTRACTS = (
     ("plugin_persona_jobs", "lease_expires_at", True),
     ("plugin_persona_jobs", "request_hash", False),
     ("plugin_persona_jobs", "input_messages_json", False),
+    ("plugin_speaker_portraits", "last_distilled_message_at", False),
+    ("plugin_speaker_portrait_jobs", "claimed_pending_messages", False),
     ("plugin_persona_jobs", "total_chunks", False),
     ("plugin_persona_jobs", "completed_chunks", False),
     ("plugin_memory_event", "source_member_id", False),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "cs-system-frontend",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/frontend/src/components/GlobalSessionBar.tsx
+++ b/frontend/src/components/GlobalSessionBar.tsx
@@ -119,17 +119,16 @@ export function GlobalSessionBar() {
       <div className="global-session-summary">
         <div className="global-session-kicker">当前操作群聊</div>
         <div className="global-session-title-row">
-          <strong>{selectedGroup ? sessionDisplayName(selectedGroup) : "尚未选择群聊"}</strong>
+          <strong title={selectedGroup?.session_id || undefined}>
+            {selectedGroup ? sessionDisplayName(selectedGroup) : "尚未选择群聊"}
+          </strong>
           <span className={`global-session-kind${selectedGroup ? " is-group" : " is-global"}`}>
             {selectedGroup ? "已验证" : "需要选择"}
           </span>
-        </div>
-        <div className="global-session-meta">
-          <span className="mono">{selectedGroup?.session_id || "不会回退到全局或任意 sessionId"}</span>
-          <span>群聊 {groups.length}</span>
+          <span className="global-session-count">{loading ? "读取中" : `${groups.length} 个群`}</span>
         </div>
         <p
-          className={`global-session-status${error ? " is-error" : ""}`}
+          className={`global-session-status${error ? " is-error" : " sr-only"}`}
           role="status"
           aria-live="polite"
         >
@@ -139,7 +138,7 @@ export function GlobalSessionBar() {
 
       <div className="global-session-controls">
         <label className="field">
-          <span>选择已同步群聊</span>
+          <span className="sr-only">选择已同步群聊</span>
           <SearchableSelect
             value={config.sessionId}
             options={options}
@@ -155,7 +154,7 @@ export function GlobalSessionBar() {
         <div className="global-session-actions">
           <button
             type="button"
-            className="button button-secondary"
+            className="button button-secondary button-compact"
             onClick={() => setReloadKey((current) => current + 1)}
             disabled={loading}
           >
@@ -163,11 +162,11 @@ export function GlobalSessionBar() {
           </button>
           <button
             type="button"
-            className="button button-secondary"
+            className="button button-secondary button-compact"
             onClick={clearSelectedGroup}
             disabled={!config.sessionId}
           >
-            清除选择
+            清除
           </button>
         </div>
       </div>

--- a/frontend/src/components/GroupScopeEmpty.tsx
+++ b/frontend/src/components/GroupScopeEmpty.tsx
@@ -1,0 +1,22 @@
+import { EmptyState } from "./EmptyState";
+import { PageHeader } from "./PageHeader";
+
+type GroupScopeEmptyProps = {
+  eyebrow: string;
+  title: string;
+  description: string;
+};
+
+export function GroupScopeEmpty({ eyebrow, title, description }: GroupScopeEmptyProps) {
+  return (
+    <div className="page-grid group-scope-empty">
+      <section className="panel panel-hero span-3">
+        <PageHeader eyebrow={eyebrow} title={title} description={description} />
+        <EmptyState
+          title="先选择一个已验证群聊"
+          description="本页不接受手填群标识，也不会回退到全局范围。请使用页面上方的群聊选择器。"
+        />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/OutputPanel.tsx
+++ b/frontend/src/components/OutputPanel.tsx
@@ -4,12 +4,13 @@ type OutputPanelProps = {
   title: string;
   value: string;
   defaultOpen?: boolean;
+  flush?: boolean;
 };
 
-export function OutputPanel({ title, value, defaultOpen = false }: OutputPanelProps) {
+export function OutputPanel({ title, value, defaultOpen = false, flush = false }: OutputPanelProps) {
   const [open, setOpen] = useState(defaultOpen);
   return (
-    <section className="panel panel-output panel-scroll">
+    <section className={flush ? "panel-output panel-output-flush" : "panel panel-output panel-scroll"}>
       <details
         className="output-details"
         open={open}

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,15 +1,21 @@
+import type { ReactNode } from "react";
+
 type PageHeaderProps = {
   eyebrow: string;
   title: string;
   description: string;
+  actions?: ReactNode;
 };
 
-export function PageHeader({ eyebrow, title, description }: PageHeaderProps) {
+export function PageHeader({ eyebrow, title, description, actions }: PageHeaderProps) {
   return (
     <div className="page-header">
-      <div>
-        <p className="section-kicker">{eyebrow}</p>
-        <h1>{title}</h1>
+      <div className="page-header-row">
+        <div className="page-header-copy">
+          <p className="section-kicker">{eyebrow}</p>
+          <h1>{title}</h1>
+        </div>
+        {actions ? <div className="page-header-actions">{actions}</div> : null}
       </div>
       <p className="page-description">{description}</p>
     </div>

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -3,6 +3,7 @@ export { DangerAction } from "./DangerAction";
 export { DataTable, type DataTableColumn } from "./DataTable";
 export { Dialog } from "./Dialog";
 export { EmptyState } from "./EmptyState";
+export { GroupScopeEmpty } from "./GroupScopeEmpty";
 export { OutputPanel } from "./OutputPanel";
 export { PageHeader } from "./PageHeader";
 export { RouteAnnouncer } from "./RouteAnnouncer";

--- a/frontend/src/pages/AmapPage.test.tsx
+++ b/frontend/src/pages/AmapPage.test.tsx
@@ -67,7 +67,8 @@ describe("AmapPage secret and concurrency controls", () => {
     expect(screen.queryByRole("textbox", { name: "AMAP_API_KEY" })).not.toBeInTheDocument();
     expect(screen.queryByRole("checkbox", { name: /清空当前高德 API Key/ })).not.toBeInTheDocument();
 
-    const timeout = screen.getByRole("spinbutton", { name: "请求超时秒数" });
+    const timeout = await screen.findByRole("spinbutton", { name: "请求超时秒数" });
+    await waitFor(() => expect(timeout).toBeEnabled());
     await user.clear(timeout);
     await user.type(timeout, "45");
     expect(screen.getByText("有未保存修改")).toBeInTheDocument();

--- a/frontend/src/pages/AmapPage.tsx
+++ b/frontend/src/pages/AmapPage.tsx
@@ -152,37 +152,39 @@ export function AmapPage() {
   return (
     <div className="page-grid">
       <UnsavedChangesGuard when={dirty} />
-      <section className="panel panel-hero span-2">
+      <section className="panel panel-hero span-3">
         <PageHeader
           eyebrow="高德地图"
           title="高德个人地图插件"
-          description="查看由外部密钥提供方注入的高德 Web 服务凭据状态，配置二维码保存目录和超时参数，并检查智能体工具注册状态。控制台永不接收或回显接口密钥。"
+          description="查看密钥注入状态，配置二维码目录和超时；控制台永不接收或回显接口密钥。"
+          actions={
+            <div className="action-row">
+              <button
+                className="button button-primary"
+                onClick={() => void saveConfig()}
+                disabled={
+                  saving ||
+                  !config.adminToken ||
+                  !data?.runtime_config_mutable ||
+                  !etag ||
+                  !Number.isFinite(Number(timeoutSeconds)) ||
+                  Number(timeoutSeconds) <= 0 ||
+                  !dirty
+                }
+              >
+                {saving ? "保存中..." : "保存配置"}
+              </button>
+              <button className="button button-secondary" onClick={() => void loadConfig()} disabled={loading || !config.adminToken}>
+                {loading ? "刷新中..." : "重新读取"}
+              </button>
+              <Link className="button button-secondary" to="/wxbot">
+                智能体工具白名单
+              </Link>
+              {dirty ? <span className="pill pill-muted">有未保存修改</span> : null}
+            </div>
+          }
         />
-        <div className="action-row">
-          <button
-            className="button button-primary"
-            onClick={() => void saveConfig()}
-            disabled={
-              saving ||
-              !config.adminToken ||
-              !data?.runtime_config_mutable ||
-              !etag ||
-              !Number.isFinite(Number(timeoutSeconds)) ||
-              Number(timeoutSeconds) <= 0 ||
-              !dirty
-            }
-          >
-            {saving ? "保存中..." : "保存配置"}
-          </button>
-          <button className="button button-secondary" onClick={() => void loadConfig()} disabled={loading || !config.adminToken}>
-            {loading ? "刷新中..." : "重新读取"}
-          </button>
-          <Link className="button button-secondary" to="/wxbot">
-            智能体工具白名单
-          </Link>
-          {dirty ? <span className="pill pill-muted">有未保存修改</span> : null}
-        </div>
-        <div className="status-grid">
+        <div className="status-grid page-hero-metrics">
           <StatusTile label="接口密钥" value={data?.api_key_configured ? "已配置" : "缺失"} />
           <StatusTile label="作用范围" value={data?.agent_scope || "群个人地图"} />
           <StatusTile label="工具数量" value={`${data?.tools?.length ?? 0}`} />
@@ -196,34 +198,7 @@ export function AmapPage() {
               : "当前部署为只读配置；请通过部署系统变更非密钥参数。"}
         </p>
         {error ? <Alert variant="danger">{error}</Alert> : null}
-      </section>
 
-      <section className="panel">
-        <div className="panel-header">
-          <div>
-            <p className="section-kicker">运行状态</p>
-            <h2>当前状态</h2>
-          </div>
-          <span className={`pill ${data?.api_key_configured ? "pill-ok" : "pill-danger"}`}>
-            {data?.api_key_configured ? "可调用" : "缺少接口密钥"}
-          </span>
-        </div>
-        <ul className="route-list">
-          <li>高德接口密钥：<span>{data?.api_key_configured ? "已配置" : "未配置"}</span></li>
-          <li>请求超时：<span>{data?.timeout_seconds ?? "-"} 秒</span></li>
-          <li>二维码目录：<span className="mono">{data?.storage_dir || "-"}</span></li>
-          <li>目录存在：<span>{data?.storage_dir_exists ? "是" : "否"}</span></li>
-          <li>目录可写：<span>{data?.storage_dir_writable ? "是" : "否"}</span></li>
-        </ul>
-      </section>
-
-      <section className="panel span-2">
-        <div className="panel-header">
-          <div>
-            <p className="section-kicker">配置</p>
-            <h2>插件配置</h2>
-          </div>
-        </div>
         <div className="form-grid">
           <div className="span-2 admin-notice">
             <strong>AMAP_API_KEY 由外部密钥提供方管理</strong>
@@ -242,7 +217,7 @@ export function AmapPage() {
               disabled={!data?.runtime_config_mutable}
             />
           </label>
-          <label className="field span-2">
+          <label className="field">
             <span>二维码保存目录</span>
             <input
               value={storageDir}
@@ -251,28 +226,21 @@ export function AmapPage() {
               disabled={!data?.runtime_config_mutable}
             />
           </label>
+          <div className="field span-2">
+            <span>智能体工具</span>
+            <div className="token-chips">
+              {(data?.tools || []).map((tool) => (
+                <span key={tool}>{tool}</span>
+              ))}
+              {!data?.tools?.length && <span>尚未读取到工具目录</span>}
+            </div>
+          </div>
         </div>
         <p className="muted-copy">
           如果微信机器人 SDK 在 Windows 侧发送图片，二维码目录要配置成 Windows 与 WSL 都能访问的共享路径。
         </p>
+        <OutputPanel flush title="高德插件配置响应" value={output} />
       </section>
-
-      <section className="panel">
-        <div className="panel-header">
-          <div>
-            <p className="section-kicker">工具目录</p>
-            <h2>智能体工具</h2>
-          </div>
-        </div>
-        <ul className="route-list">
-          {(data?.tools || []).map((tool) => (
-            <li key={tool}><span className="mono">{tool}</span></li>
-          ))}
-          {!data?.tools?.length && <li>尚未读取到工具目录</li>}
-        </ul>
-      </section>
-
-      <OutputPanel title="高德插件配置响应" value={output} />
     </div>
   );
 }

--- a/frontend/src/pages/CommandsPage.tsx
+++ b/frontend/src/pages/CommandsPage.tsx
@@ -43,7 +43,28 @@ type CommandDraft = {
 type ConfigStatus = "idle" | "loading" | "loaded" | "saving" | "error" | "conflict";
 
 function countItems(value: string) {
-  return value.split(/\n|,/).map((item) => item.trim()).filter(Boolean).length;
+  return parseListItems(value).length;
+}
+
+function parseListItems(value: string) {
+  return value.split(/\n|,/).map((item) => item.trim()).filter(Boolean);
+}
+
+function TokenPreview({ value }: { value: string }) {
+  const items = parseListItems(value);
+  if (!items.length) {
+    return null;
+  }
+  const visible = items.slice(0, 6);
+  const rest = items.length - visible.length;
+  return (
+    <div className="token-chips" aria-hidden="true">
+      {visible.map((item) => (
+        <span key={item}>{item}</span>
+      ))}
+      {rest > 0 ? <span>+{rest}</span> : null}
+    </div>
+  );
 }
 
 const CONFIG_STATUS_LABELS: Record<ConfigStatus, string> = {
@@ -184,16 +205,35 @@ export function CommandsPage() {
   return (
     <div className="page-grid">
       <UnsavedChangesGuard when={configDirty} />
-      <section className="panel span-2">
+      <section className="panel span-3">
         <PageHeader
           eyebrow="命令中心"
           title="全局命令中心"
-          description="统一管理聊天命令、管理员成员标识和普通 / 管理员命令清单。积分与绘图能力已接入这里，避免继续分散在各插件中。"
+          description="统一管理聊天命令、管理员成员标识和普通 / 管理员命令清单。"
+          actions={
+            <div className="action-row">
+              <button
+                className="button button-secondary"
+                onClick={() => void loadConfig()}
+                disabled={configDirty || configStatus === "loading" || configStatus === "saving"}
+              >
+                {configStatus === "loading" ? "读取中…" : "读取配置"}
+              </button>
+              {configDirty ? (
+                <button className="button button-secondary" onClick={discardDraft}>
+                  放弃未保存修改
+                </button>
+              ) : null}
+              <button
+                className="button button-primary"
+                onClick={() => void saveConfig()}
+                disabled={!configLoadedForScope || !configDirty || configStatus === "saving" || configStatus === "loading"}
+              >
+                {configStatus === "saving" ? "保存中…" : "保存配置"}
+              </button>
+            </div>
+          }
         />
-
-        <p className="muted-copy">
-          当前为租户级配置，会影响该租户下所有接入命令中心的会话。
-        </p>
 
         <div className="summary-grid">
           <div className="summary-card">
@@ -215,65 +255,53 @@ export function CommandsPage() {
         </div>
       </section>
 
-      <section className="panel span-2">
+      <section className="panel span-3">
         <div className="panel-header">
           <div>
             <p className="section-kicker">配置</p>
             <h3>租户级命令权限</h3>
           </div>
         </div>
-        <div className="form-grid">
-          <label className="field span-2">
+        <div className="commands-lists">
+          <label className="field">
             <span>管理员成员标识</span>
-            <textarea
-              rows={5}
-              value={adminUserIdsText}
-              onChange={(event) => setAdminUserIdsText(event.target.value)}
-              disabled={!configLoadedForScope || configStatus === "loading" || configStatus === "saving"}
-              placeholder={"每行一个成员微信标识\n例如：wxid_xxx"}
-            />
+            <div className="token-field">
+              <TokenPreview value={adminUserIdsText} />
+              <textarea
+                rows={4}
+                value={adminUserIdsText}
+                onChange={(event) => setAdminUserIdsText(event.target.value)}
+                disabled={!configLoadedForScope || configStatus === "loading" || configStatus === "saving"}
+                placeholder={"每行一个成员微信标识\n例如：wxid_xxx"}
+              />
+            </div>
           </label>
-          <label className="field span-2">
+          <label className="field">
             <span>普通用户可用命令</span>
-            <textarea
-              rows={7}
-              value={userCommandsText}
-              onChange={(event) => setUserCommandsText(event.target.value)}
-              disabled={!configLoadedForScope || configStatus === "loading" || configStatus === "saving"}
-              placeholder={"/签到\n/checkin\n/余额\n/balance"}
-            />
+            <div className="token-field">
+              <TokenPreview value={userCommandsText} />
+              <textarea
+                rows={4}
+                value={userCommandsText}
+                onChange={(event) => setUserCommandsText(event.target.value)}
+                disabled={!configLoadedForScope || configStatus === "loading" || configStatus === "saving"}
+                placeholder={"/签到\n/checkin\n/余额\n/balance"}
+              />
+            </div>
           </label>
-          <label className="field span-2">
+          <label className="field">
             <span>管理员可用命令</span>
-            <textarea
-              rows={7}
-              value={adminCommandsText}
-              onChange={(event) => setAdminCommandsText(event.target.value)}
-              disabled={!configLoadedForScope || configStatus === "loading" || configStatus === "saving"}
-              placeholder={"/赠送\n/grant\n/sign-in\n/signin\n/签到模式"}
-            />
+            <div className="token-field">
+              <TokenPreview value={adminCommandsText} />
+              <textarea
+                rows={4}
+                value={adminCommandsText}
+                onChange={(event) => setAdminCommandsText(event.target.value)}
+                disabled={!configLoadedForScope || configStatus === "loading" || configStatus === "saving"}
+                placeholder={"/赠送\n/grant\n/sign-in\n/signin\n/签到模式"}
+              />
+            </div>
           </label>
-        </div>
-        <div className="action-row">
-          <button
-            className="button button-secondary"
-            onClick={() => void loadConfig()}
-            disabled={configDirty || configStatus === "loading" || configStatus === "saving"}
-          >
-            {configStatus === "loading" ? "读取中…" : "读取配置"}
-          </button>
-          {configDirty ? (
-            <button className="button button-secondary" onClick={discardDraft}>
-              放弃未保存修改
-            </button>
-          ) : null}
-          <button
-            className="button button-primary"
-            onClick={() => void saveConfig()}
-            disabled={!configLoadedForScope || !configDirty || configStatus === "saving" || configStatus === "loading"}
-          >
-            {configStatus === "saving" ? "保存中…" : "保存配置"}
-          </button>
         </div>
         <div className="route-list" aria-live="polite">
           <div>
@@ -308,7 +336,7 @@ export function CommandsPage() {
         </p>
       </section>
 
-      <section className="panel span-2">
+      <section className="panel span-3">
         <div className="panel-header">
           <div>
             <p className="section-kicker">命令目录</p>
@@ -320,32 +348,36 @@ export function CommandsPage() {
             <caption className="sr-only">已注册命令目录</caption>
             <thead>
               <tr>
-                <th scope="col">插件</th>
-                <th scope="col">主命令</th>
-                <th scope="col">别名</th>
+                <th scope="col">命令</th>
                 <th scope="col">权限</th>
                 <th scope="col">说明</th>
-                <th scope="col">用法</th>
               </tr>
             </thead>
             <tbody>
               {catalog.map((item) => (
                 <tr key={`${item.plugin_name}-${item.command}`}>
-                  <td><TechnicalDetails summary="查看提供方标识" value={item.plugin_name} /></td>
-                  <td className="mono">{item.command}</td>
-                  <td className="mono">{(item.aliases || []).join(", ") || "-"}</td>
+                  <td>
+                    <div className="command-catalog-cmd">
+                      <strong className="mono">{item.command}</strong>
+                      <small>{item.plugin_name}{(item.aliases || []).length ? ` · ${(item.aliases || []).join(", ")}` : ""}</small>
+                    </div>
+                  </td>
                   <td>
                     <span className={`pill ${item.admin_only ? "pill-danger" : "pill-ok"}`}>
                       {item.admin_only ? "仅管理员" : "所有成员"}
                     </span>
                   </td>
-                  <td>{item.description || "-"}</td>
-                  <td className="mono">{item.usage || "-"}</td>
+                  <td>
+                    <div className="command-catalog-help">
+                      <span>{item.description || "-"}</span>
+                      {item.usage ? <code>{item.usage}</code> : null}
+                    </div>
+                  </td>
                 </tr>
               ))}
               {!catalog.length && (
                 <tr>
-                  <td colSpan={6} className="empty-cell">
+                  <td colSpan={3} className="empty-cell">
                     当前还没有插件向命令中心注册命令。
                   </td>
                 </tr>
@@ -353,9 +385,8 @@ export function CommandsPage() {
             </tbody>
           </table>
         </div>
+        <OutputPanel flush title="命令中心接口结果" value={output} />
       </section>
-
-      <OutputPanel title="命令中心接口结果" value={output} />
     </div>
   );
 }

--- a/frontend/src/pages/DlqPage.tsx
+++ b/frontend/src/pages/DlqPage.tsx
@@ -95,13 +95,23 @@ export function DlqPage() {
 
   return (
     <div className="page-grid">
-      <section className="panel span-2">
+      <section className="panel span-3">
         <PageHeader
           eyebrow="失败消息队列"
           title="死信队列处置台"
-          description="这个页面独立出来后，后面你可以继续扩成重放审批、失败原因过滤和批量回放。"
+          description="按消息标识列出、查看、重放或删除死信记录。"
+          actions={
+            <div className="action-row">
+              <button className="button button-primary" onClick={() => void listMessages()}>
+                列出消息
+              </button>
+              <button className="button button-secondary" onClick={() => void getMessage()}>
+                查看单条
+              </button>
+            </div>
+          }
         />
-        <div className="form-grid">
+        <div className="page-ops-bar">
           <label className="field">
             <span>消息标识</span>
             <input value={entryId} onChange={(event) => setEntryId(event.target.value)} />
@@ -123,12 +133,6 @@ export function DlqPage() {
           </label>
         </div>
         <div className="action-row">
-          <button className="button button-secondary" onClick={() => void listMessages()}>
-            列出消息
-          </button>
-          <button className="button button-secondary" onClick={() => void getMessage()}>
-            查看单条
-          </button>
           <DangerAction
             label="重放消息"
             title="确认重放死信消息"
@@ -160,9 +164,8 @@ export function DlqPage() {
             onConfirm={deleteMessage}
           />
         </div>
+        <OutputPanel flush title="失败消息队列响应" value={output} />
       </section>
-
-      <OutputPanel title="失败消息队列响应" value={output} />
     </div>
   );
 }

--- a/frontend/src/pages/GroupBehaviorPage.tsx
+++ b/frontend/src/pages/GroupBehaviorPage.tsx
@@ -1,6 +1,6 @@
 import {
   Alert,
-  EmptyState,
+  GroupScopeEmpty,
   PageHeader,
   Tabs,
   UnsavedChangesGuard,
@@ -80,21 +80,11 @@ export function GroupBehaviorPage() {
 
   if (!groupId) {
     return (
-      <div className="page-grid group-behavior-page">
-        <section className="panel panel-hero span-3">
-          <PageHeader
-            eyebrow="群聊行为控制"
-            title="群参与与行为"
-            description="把机器人何时开口、说多少、用什么风格以及成员隐私边界，集中在一个可审计的群级控制面。"
-          />
-        </section>
-        <div className="span-3">
-          <EmptyState
-            title="先选择一个已验证群聊"
-            description="本页不接受手填群标识，也不会回退到全局范围。请使用页面上方的群聊选择器。"
-          />
-        </div>
-      </div>
+      <GroupScopeEmpty
+        eyebrow="群聊行为控制"
+        title="群参与与行为"
+        description="把机器人何时开口、说多少、用什么风格以及成员隐私边界，集中在一个可审计的群级控制面。"
+      />
     );
   }
 
@@ -210,9 +200,35 @@ export function GroupBehaviorPage() {
           eyebrow="群聊行为控制"
           title="群参与与行为"
           description="在当前群统一控制何时开口、参与预算、表达风格与成员隐私；所有写入都带版本保护、稳定重试标识和审计原因。"
+          actions={
+            <div className="action-row">
+              <button
+                className="button button-primary"
+                type="button"
+                onClick={() => void savePolicy()}
+                disabled={
+                  !policyState.dirty
+                  || policyState.status === "saving"
+                  || Boolean(voiceValidationError)
+                }
+              >
+                {policyState.status === "saving" ? "保存中…" : "保存群策略"}
+              </button>
+              <button
+                className="button button-secondary"
+                type="button"
+                onClick={reloadPolicy}
+                disabled={policyState.status === "loading"}
+              >
+                重新读取
+              </button>
+              <span className={`pill ${effectiveEnabled ? "pill-ok" : "pill-danger"}`}>
+                {effectiveEnabled ? "有效参与开启" : "有效参与关闭"}
+              </span>
+            </div>
+          }
         />
-        <div className="status-grid">
-          <article className="status-tile"><span>目标群</span><strong>{groupId}</strong></article>
+        <div className="status-grid page-hero-metrics">
           <article className="status-tile"><span>策略版本</span><strong>{policyDraft ? `v${policyDraft.version}` : "—"}</strong></article>
           <article className="status-tile"><span>同步状态</span><strong>{resourceStatus(policyState)}</strong></article>
         </div>
@@ -230,31 +246,6 @@ export function GroupBehaviorPage() {
                 )}
           </Alert>
         ) : null}
-        <div className="action-row">
-          <button
-            className="button button-primary"
-            type="button"
-            onClick={() => void savePolicy()}
-            disabled={
-              !policyState.dirty
-              || policyState.status === "saving"
-              || Boolean(voiceValidationError)
-            }
-          >
-            {policyState.status === "saving" ? "保存中…" : "保存群策略"}
-          </button>
-          <button
-            className="button button-secondary"
-            type="button"
-            onClick={reloadPolicy}
-            disabled={policyState.status === "loading"}
-          >
-            重新读取
-          </button>
-          <span className={`pill ${effectiveEnabled ? "pill-ok" : "pill-danger"}`}>
-            {effectiveEnabled ? "有效参与开启" : "有效参与关闭"}
-          </span>
-        </div>
         <TechnicalDetails
           summary="查看策略技术详情"
           label="群策略技术详情 JSON"

--- a/frontend/src/pages/HighRiskActions.test.tsx
+++ b/frontend/src/pages/HighRiskActions.test.tsx
@@ -1,6 +1,7 @@
 import axe from "axe-core";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { apiRequest } from "../lib/api";
@@ -124,7 +125,11 @@ describe("high-risk action dialogs", () => {
       return {};
     });
 
-    render(<PluginMarketplacePage />);
+    render(
+      <MemoryRouter>
+        <PluginMarketplacePage />
+      </MemoryRouter>,
+    );
     await user.click(await screen.findByRole("button", { name: "卸载插件" }));
 
     const dialog = screen.getByRole("dialog", { name: "确认卸载 Memory" });
@@ -187,7 +192,11 @@ describe("high-risk action dialogs", () => {
       return {};
     });
 
-    render(<PluginMarketplacePage />);
+    render(
+      <MemoryRouter>
+        <PluginMarketplacePage />
+      </MemoryRouter>,
+    );
     await user.click(await screen.findByRole("button", { name: "预览安装" }));
     await waitFor(() => {
       expect(apiRequestMock.mock.calls.some(([, path]) => path === "/v1/admin/plugins/install/preview")).toBe(true);

--- a/frontend/src/pages/KnowledgePage.tsx
+++ b/frontend/src/pages/KnowledgePage.tsx
@@ -66,7 +66,9 @@ export function KnowledgePage() {
       ) : (
         <ImportWorkspace importer={importer} currentScopeText={scope.currentScopeText} />
       )}
-      <OutputPanel title="知识运营响应" value={output} />
+      <section className="panel span-3">
+        <OutputPanel flush title="知识运营响应" value={output} />
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/LlmConfigPage.tsx
+++ b/frontend/src/pages/LlmConfigPage.tsx
@@ -129,7 +129,7 @@ function changedPayload(
 }
 
 function SourceBadge({ source }: { source: FieldSource | undefined }) {
-  if (!source) {
+  if (!source || source === "environment" || source === "dotenv_or_default") {
     return null;
   }
   return (
@@ -288,38 +288,49 @@ export function LlmConfigPage() {
         <PageHeader
           eyebrow="运行时模型控制"
           title="大模型配置"
-          description="直接编辑并保存非敏感模型参数。控制台版本会覆盖运行环境中的默认值；密钥提供方仍保持只读。保存不会改写部署文件，也不会热替换正在服务的模型。"
+          description="直接编辑并保存非敏感模型参数。控制台版本会覆盖运行环境默认值；密钥提供方只读。保存不会改写部署文件，也不会热替换正在服务的模型。"
+          actions={
+            <div className="action-row">
+              <button
+                type="button"
+                className="button button-primary"
+                onClick={() => void saveConfig()}
+                disabled={!dirty || !etag || status === "saving" || status === "loading" || status === "conflict"}
+              >
+                {status === "saving" ? "提交版本中…" : "保存为新版本"}
+              </button>
+              <button
+                type="button"
+                className="button button-secondary"
+                onClick={() => void loadConfig(true)}
+                disabled={status === "loading" || status === "saving"}
+              >
+                {status === "loading" ? "读取中…" : dirty ? "放弃草稿并重新读取" : "重新读取"}
+              </button>
+              {dirty ? (
+                <button type="button" className="button button-ghost" onClick={discardDraft}>
+                  还原本地草稿
+                </button>
+              ) : null}
+            </div>
+          }
         />
-        <div className="action-row">
-          <button
-            type="button"
-            className="button button-primary"
-            onClick={() => void saveConfig()}
-            disabled={!dirty || !etag || status === "saving" || status === "loading" || status === "conflict"}
-          >
-            {status === "saving" ? "提交版本中…" : "保存为新版本"}
-          </button>
-          <button
-            type="button"
-            className="button button-secondary"
-            onClick={() => void loadConfig(true)}
-            disabled={status === "loading" || status === "saving"}
-          >
-            {status === "loading" ? "读取中…" : dirty ? "放弃草稿并重新读取" : "重新读取"}
-          </button>
-          {dirty ? (
-            <button type="button" className="button button-ghost" onClick={discardDraft}>
-              还原本地草稿
-            </button>
-          ) : null}
-        </div>
 
         <div className="status-grid" aria-live="polite">
           <StatusTile label="状态" value={STATUS_LABELS[status]} />
           <StatusTile label="配置版本" value={loadedConfig ? `v${loadedConfig.version}` : "未加载"} />
           <StatusTile label="待保存" value={dirty ? "有本地修改" : "无"} />
           <StatusTile label="可编辑字段" value={`${DRAFT_FIELDS.length - lockedCount}`} />
-          <StatusTile label="影响服务" value={loadedConfig?.affected_roles.map(roleLabel).join(" / ") || "-"} />
+          <StatusTile
+            label="影响服务"
+            value={
+              loadedConfig?.affected_roles.length
+                ? loadedConfig.affected_roles.length > 2
+                  ? `${loadedConfig.affected_roles.length} 个服务`
+                  : loadedConfig.affected_roles.map(roleLabel).join("、")
+                : "-"
+            }
+          />
           <StatusTile
             label="OpenAI 凭据"
             value={secretStatus?.configured ? "由外部提供" : "未配置"}
@@ -389,6 +400,7 @@ export function LlmConfigPage() {
           </div>
         ) : (
           <div className="form-grid">
+            <p className="muted-copy span-2">未标注来源的字段使用运行环境默认值；控制台覆盖和密钥提供方会单独标出。</p>
             <label className="field">
               <span>聊天模型提供方</span>
               <SourceBadge source={sourceFor("llm_provider")} />
@@ -488,7 +500,7 @@ export function LlmConfigPage() {
       </section>
 
       <div className="span-3">
-        <OutputPanel title="安全响应（不含密钥）" value={output} />
+        <OutputPanel flush title="安全响应（不含密钥）" value={output} />
       </div>
     </div>
   );

--- a/frontend/src/pages/MessageQueuesPage.tsx
+++ b/frontend/src/pages/MessageQueuesPage.tsx
@@ -668,14 +668,44 @@ export function MessageQueuesPage() {
 
   return (
     <div className="page-grid queue-page">
-      <section className="panel panel-hero span-2">
+      <section className="panel panel-hero span-3">
         <PageHeader
           eyebrow="消息总线"
           title="全局消息队列"
-          description="统一查看全局入站、出站和死信流，确认消息有没有真正进队、出队，以及消费者是否积压。"
+          description="查看入站、出站和死信流，确认进队、出队与积压。"
+          actions={
+            <div className="action-row">
+              <button className="button button-primary" type="button" onClick={() => void refreshAll()} disabled={loading}>
+                {loading ? "刷新中..." : "立即刷新"}
+              </button>
+              {pageCursor && (
+                <button
+                  className="button button-secondary"
+                  type="button"
+                  onClick={() => {
+                    setPageCursor("");
+                    setAutoRefresh(true);
+                    void refreshAll();
+                  }}
+                  disabled={loading}
+                >
+                  回到最新
+                </button>
+              )}
+              <label className="queue-auto-refresh-toggle">
+                <input
+                  type="checkbox"
+                  checked={autoRefresh && !pageCursor}
+                  disabled={Boolean(pageCursor)}
+                  onChange={(event) => setAutoRefresh(event.target.checked)}
+                />
+                <span>自动刷新</span>
+              </label>
+            </div>
+          }
         />
         <form
-          className="form-grid"
+          className="page-ops-bar"
           onSubmit={(event) => {
             event.preventDefault();
             void refreshAll();
@@ -714,36 +744,6 @@ export function MessageQueuesPage() {
             <input value={traceFilter} onChange={(event) => setTraceFilter(event.target.value)} placeholder="可选" />
           </label>
         </form>
-        <div className="queue-refresh-toolbar">
-          <div className="action-row">
-            <button className="button button-primary" type="button" onClick={() => void refreshAll()} disabled={loading}>
-              {loading ? "刷新中..." : "立即刷新"}
-            </button>
-            {pageCursor && (
-              <button
-                className="button button-secondary"
-                type="button"
-                onClick={() => {
-                  setPageCursor("");
-                  setAutoRefresh(true);
-                  void refreshAll();
-                }}
-                disabled={loading}
-              >
-                回到最新
-              </button>
-            )}
-          </div>
-          <label className="queue-auto-refresh-toggle">
-            <input
-              type="checkbox"
-              checked={autoRefresh && !pageCursor}
-              disabled={Boolean(pageCursor)}
-              onChange={(event) => setAutoRefresh(event.target.checked)}
-            />
-            <span>自动刷新</span>
-          </label>
-        </div>
         <div className="queue-live-status" role="status" aria-live="polite">
           <span className={`queue-live-dot${autoRefresh && !pageCursor ? " active" : ""}`} aria-hidden="true" />
           <span>{refreshStatus}</span>
@@ -756,16 +756,7 @@ export function MessageQueuesPage() {
           <StatusTile label="消息总数" value={String(currentSummary?.length ?? 0)} />
           <StatusTile label="待确认" value={String(currentSummary?.pending_total ?? 0)} />
         </div>
-      </section>
-
-      <section className="panel panel-scroll">
-        <div className="panel-header">
-          <div>
-            <p className="section-kicker">队列流</p>
-            <h3>流摘要</h3>
-          </div>
-        </div>
-        <div className="queue-summary-list">
+        <div className="queue-summary-list" aria-label="流摘要">
           {summary.map((item) => (
             <button
               key={item.stream_key}
@@ -775,7 +766,6 @@ export function MessageQueuesPage() {
             >
               <div className="queue-summary-card-top">
                 <strong>{streamLabel(item.stream_key)}</strong>
-                <span>消息流摘要</span>
               </div>
               <div className="queue-summary-card-stats">
                 <span>总量 {item.length}</span>
@@ -787,31 +777,34 @@ export function MessageQueuesPage() {
           {!summary.length && <p className="muted-copy">暂无队列摘要</p>}
         </div>
         {!!currentSummary?.groups?.length && (
-          <div className="table-wrap compact-table-scroll u-mt-4">
-            <table>
-              <caption className="sr-only">当前消息流消费组摘要</caption>
-              <thead>
-                <tr>
-                  <th scope="col">消费组</th>
-                  <th scope="col">消费者</th>
-                  <th scope="col">待处理</th>
-                  <th scope="col">延迟</th>
-                  <th scope="col">投递状态</th>
-                </tr>
-              </thead>
-              <tbody>
-                {currentSummary.groups.map((group) => (
-                  <tr key={group.name}>
-                    <td>消费组</td>
-                    <td>{group.consumers}</td>
-                    <td>{group.pending}</td>
-                    <td>{group.lag ?? "-"}</td>
-                    <td>{group.last_delivered_id ? "已有投递" : "暂无投递"}</td>
+          <details className="queue-groups-disclosure">
+            <summary>当前流消费组</summary>
+            <div className="table-wrap compact-table-scroll">
+              <table>
+                <caption className="sr-only">当前消息流消费组摘要</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">消费组</th>
+                    <th scope="col">消费者</th>
+                    <th scope="col">待处理</th>
+                    <th scope="col">延迟</th>
+                    <th scope="col">投递状态</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {currentSummary.groups.map((group) => (
+                    <tr key={group.name}>
+                      <td>消费组</td>
+                      <td>{group.consumers}</td>
+                      <td>{group.pending}</td>
+                      <td>{group.lag ?? "-"}</td>
+                      <td>{group.last_delivered_id ? "已有投递" : "暂无投递"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </details>
         )}
       </section>
 
@@ -1032,7 +1025,7 @@ export function MessageQueuesPage() {
       </section>
 
       <div className="span-3">
-        <OutputPanel title="最近响应" value={output} />
+        <OutputPanel flush title="最近响应" value={output} />
       </div>
     </div>
   );

--- a/frontend/src/pages/ModerationPage.tsx
+++ b/frontend/src/pages/ModerationPage.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { DangerAction } from "../components/DangerAction";
+import { GroupScopeEmpty } from "../components/GroupScopeEmpty";
 import { OutputPanel } from "../components/OutputPanel";
 import { PageHeader } from "../components/PageHeader";
-import { SearchableSelect } from "../components/SearchableSelect";
 import { UnsavedChangesGuard } from "../components/UnsavedChangesGuard";
 import { TechnicalDetails } from "../components/TechnicalDetails";
 import {
@@ -120,16 +120,6 @@ function formatTimestamp(value?: string | null) {
   }).format(date);
 }
 
-function modeLabel(mode: string) {
-  if (mode === "append") {
-    return "追加提醒";
-  }
-  if (mode === "replace") {
-    return "直接拦截";
-  }
-  return "仅留痕";
-}
-
 const RESOURCE_STATUS_LABELS: Record<ResourceStatus, string> = {
   idle: "等待读取",
   loading: "正在读取",
@@ -153,10 +143,6 @@ function webhookStatusLabel(status?: string) {
     pending: "等待发送",
     "skipped:no_url": "未配置地址，已跳过",
   } as Record<string, string>)[status || ""] || (status ? "其他状态" : "-");
-}
-
-function buildSessionOptionLabel(session: ModerationSessionSummary) {
-  return `${session.session_name || session.session_id}（已验证群聊）`;
 }
 
 export function mergeSessions(
@@ -200,7 +186,6 @@ export function ModerationPage() {
     config,
     verifiedGroupIds,
     registerVerifiedGroups,
-    selectVerifiedGroup,
   } = useConsoleConfig();
   const { keyFor, clear } = useStableIdempotencyKeys();
   const basePath = "/plugins/moderation";
@@ -239,19 +224,6 @@ export function ModerationPage() {
   const selectedEvent = useMemo(
     () => events.find((item) => item.id === selectedEventId) || null,
     [events, selectedEventId],
-  );
-  const selectedSession = useMemo(
-    () => sessions.find((item) => item.session_id === effectiveSessionId) || null,
-    [effectiveSessionId, sessions],
-  );
-  const sessionOptions = useMemo(
-    () =>
-      sessions.map((item) => ({
-        value: item.session_id,
-        label: buildSessionOptionLabel(item),
-        keywords: [item.session_id, item.session_name || ""],
-      })),
-    [sessions],
   );
   const resourceScope = `${config.tenantId}\u0000${effectiveSessionId}`;
   const configLoadedForScope = Boolean(
@@ -770,17 +742,41 @@ export function ModerationPage() {
     void loadEvents();
   }, [loadEvents]);
 
+  if (!scopeReady) {
+    return (
+      <GroupScopeEmpty
+        eyebrow="内容审核"
+        title="审核配置与事件运营"
+        description="按当前已验证群聊配置审核开关、提醒和关键词。群聊请在顶部会话条切换。"
+      />
+    );
+  }
+
   return (
     <div className="page-grid moderation-page">
       <UnsavedChangesGuard when={hasUnsavedChanges} />
-      <section className="panel span-2 moderation-overview-panel">
+      <section className="panel span-3 moderation-overview-panel">
         <PageHeader
           eyebrow="内容审核"
           title="审核配置与事件运营"
-          description="页面按群维度组织审核插件：先选群，再配置命中动作和关键词，最后看最近事件。即使没有旧项目那套单页后台，也能在这里直接完成日常运营操作。"
+          description="按当前群配置审核开关、提醒和关键词。命中后可只留痕、追加提醒或拦截回复。"
+          actions={
+            <div className="action-row">
+              <button className="button button-secondary button-compact" onClick={() => void loadSessions()}>
+                刷新群列表
+              </button>
+              <button
+                className="button button-secondary button-compact"
+                onClick={() => void refreshSelected()}
+                disabled={!scopeReady || hasUnsavedChanges}
+              >
+                刷新当前群
+              </button>
+            </div>
+          }
         />
 
-        <div className="summary-grid moderation-summary-grid">
+        <div className="summary-grid page-hero-metrics">
           <div className="summary-card" data-status={sessions.length ? "ok" : "warning"}>
             <span>可管理群</span>
             <strong>{sessions.length}</strong>
@@ -798,98 +794,7 @@ export function ModerationPage() {
             <strong>{events.length}</strong>
           </div>
         </div>
-
-        <div className="moderation-session-toolbar">
-          <label className="field span-2">
-            <span>管理群选择</span>
-            <SearchableSelect
-              value={sessionId}
-              options={sessionOptions}
-              disabled={hasUnsavedChanges}
-              onChange={(value) => {
-                setSessionId(value);
-                if (value) {
-                  selectVerifiedGroup(value);
-                }
-              }}
-              placeholder="从已同步群聊中选择"
-              searchPlaceholder="输入群名搜索"
-              emptyText="暂无可管理群，请先在微信机器人页同步群聊"
-              noResultsText="没有匹配群会话"
-            />
-          </label>
-          <div className="moderation-toolbar-actions">
-            <button className="button button-secondary" onClick={() => void loadSessions()}>
-              刷新群列表
-            </button>
-            <button
-              className="button button-secondary"
-              onClick={() => void refreshSelected()}
-              disabled={!scopeReady || hasUnsavedChanges}
-            >
-              刷新当前群
-            </button>
-          </div>
-        </div>
-
-        <div className="data-flow-note moderation-flow-note">
-          <strong>现在这条线怎么工作</strong>
-          <span>审核会在消息预处理完成后做关键词包含匹配，命中后立即留存事件，再按配置决定只留痕、追加提醒，还是直接拦截回复。</span>
-          <span>外部回调当前发送结构化事件数据，不会自动转换成企业微信群消息模板。</span>
-        </div>
       </section>
-
-      <aside className="panel panel-sidebar moderation-side-stack">
-        <section className="panel moderation-side-card">
-          <div className="panel-header">
-            <div>
-              <p className="section-kicker">当前群聊</p>
-              <h3>当前群概况</h3>
-            </div>
-          </div>
-          <div className="moderation-meta-list">
-            <div>
-              <span>群名称</span>
-              <strong>{selectedSession?.session_name || "-"}</strong>
-            </div>
-            <details>
-              <summary>技术标识</summary>
-              <strong className="mono">{effectiveSessionId || "-"}</strong>
-            </details>
-            <div>
-              <span>审核状态</span>
-              <strong>{enabled === "true" ? "已开启" : "未开启"}</strong>
-            </div>
-            <div>
-              <span>提醒动作</span>
-              <strong>{modeLabel(reminderMode)}</strong>
-            </div>
-            <div>
-              <span>最后命中</span>
-              <strong>{formatTimestamp(events[0]?.created_at || selectedSession?.last_event_at)}</strong>
-            </div>
-          </div>
-        </section>
-
-        <section className="panel moderation-side-card">
-          <div className="panel-header">
-            <div>
-              <p className="section-kicker">操作说明</p>
-              <h3>配置说明</h3>
-            </div>
-          </div>
-          <ul className="moderation-guidance-list">
-            <li>先从群列表里选群，再改配置。页面里所有保存动作都只针对当前群。</li>
-            <li>关键词区以“每行一个词”的整体替换为主，适合运营同学直接维护群规则。</li>
-            <li>`追加提醒` 保留原回复并在末尾补警示，`直接拦截` 会用提醒文案替换原回复。</li>
-            <li>外部回调开启后，会发送群聊、触发成员、消息、命中词与追踪信息。</li>
-          </ul>
-          <TechnicalDetails
-            summary="查看外部回调字段"
-            value={["session_id", "user_id", "message_text", "matched_keywords", "trace_id"]}
-          />
-        </section>
-      </aside>
 
       <section className="panel span-2 moderation-config-panel">
         <div className="panel-header">
@@ -947,7 +852,7 @@ export function ModerationPage() {
               <option value="true">开启</option>
             </select>
           </label>
-          <label className="field span-2">
+          <label className="field">
             <span>外部回调地址</span>
             <input
               value={webhookUrl}
@@ -957,11 +862,10 @@ export function ModerationPage() {
             />
           </label>
         </div>
-
-        <div className="moderation-inline-note">
-          <strong>字段解释</strong>
-          <span>如果你只想“留痕并回看”，把动作设成 `只记事件` 即可；只有真的要干预回复时，才改成追加或拦截。</span>
-        </div>
+        <TechnicalDetails
+          summary="查看外部回调字段"
+          value={["session_id", "user_id", "message_text", "matched_keywords", "trace_id"]}
+        />
 
         <div className="action-row">
           <button
@@ -1279,9 +1183,11 @@ export function ModerationPage() {
         </div>
       </section>
 
-      <OutputPanel title="群列表与索引响应" value={sessionOutput} />
-      <OutputPanel title="审核配置响应" value={configOutput} />
-      <OutputPanel title={selectedEvent ? `审核事件 #${selectedEvent.id}` : "审核操作响应"} value={selectedEvent ? formatJson(selectedEvent) : opsOutput} />
+      <section className="panel span-3">
+        <OutputPanel flush title="群列表与索引响应" value={sessionOutput} />
+        <OutputPanel flush title="审核配置响应" value={configOutput} />
+        <OutputPanel flush title={selectedEvent ? `审核事件 #${selectedEvent.id}` : "审核操作响应"} value={selectedEvent ? formatJson(selectedEvent) : opsOutput} />
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/OverviewPage.test.tsx
+++ b/frontend/src/pages/OverviewPage.test.tsx
@@ -146,7 +146,7 @@ describe("OverviewPage degraded loading", () => {
 
     await user.click(screen.getByRole("button", { name: "重新打开清单" }));
     expect(screen.getByRole("heading", { name: "从依赖检查到正式参与" })).toBeInTheDocument();
-    expect(window.localStorage.getItem("agent-console:launch-checklist:v1:default")).toBeNull();
+    expect(window.localStorage.getItem("agent-console:launch-checklist:v1:default")).toBe("open");
   });
 
   it("renders an explicit empty launch state instead of claiming zero of zero steps are ready", () => {
@@ -165,7 +165,7 @@ describe("OverviewPage degraded loading", () => {
     expect(checklist).not.toBeNull();
     const scope = within(checklist as HTMLElement);
     expect(scope.getByText("暂无上线步骤")).toBeInTheDocument();
-    expect(scope.getByText(/这不表示所有能力已就绪/)).toBeInTheDocument();
+    expect(scope.getByText("当前没有可执行的上线步骤。")).toBeInTheDocument();
     expect(scope.getByLabelText("上线步骤尚未生成")).toHaveTextContent("暂无步骤尚未生成");
     expect(scope.queryByText("0/0")).not.toBeInTheDocument();
     expect(scope.queryByRole("list")).not.toBeInTheDocument();
@@ -214,10 +214,15 @@ describe("OverviewPage degraded loading", () => {
       </ConsoleConfigProvider>,
     );
 
-    expect(screen.getByRole("heading", { name: "从授权群到安全参与" })).toBeInTheDocument();
+    expect(screen.getByText("上线清单已收起")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "授权群工作台" })).toBeInTheDocument();
     expect(screen.queryByText("后端运行概览")).not.toBeInTheDocument();
     expect(screen.queryByText("插件与适配器摘要")).not.toBeInTheDocument();
+    expect(apiRequestMock).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "重新打开清单" }));
+    expect(screen.getByRole("heading", { name: "从授权群到安全参与" })).toBeInTheDocument();
+    expect(screen.queryByText("后端运行概览")).not.toBeInTheDocument();
     expect(apiRequestMock).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/OverviewPage.tsx
+++ b/frontend/src/pages/OverviewPage.tsx
@@ -79,6 +79,28 @@ const CAPABILITY_STATE_LABELS: Record<CapabilityHealth, string> = {
   degraded: "已降级",
 };
 
+const CAPABILITY_REASON_LABELS: Record<string, string> = {
+  plugin_not_active: "插件未启用",
+  plugin_not_loaded: "插件未加载",
+  plugin_not_configured: "未配置",
+  plugin_disabled_for_tenant: "当前租户已停用",
+  plugin_active_for_tenant: "当前租户已启用",
+  tenant_scope_state_unavailable: "租户插件状态暂时不可用",
+  required_plugin_dependency_unavailable: "必需依赖不可用",
+  adapter_connection_verified: "连接已验证",
+  adapter_connection_configured_unverified: "连接已配置，尚未验证",
+  adapter_available_connection_unverified: "适配器可用，连接尚未验证",
+  connection_required: "需要完成平台连接",
+  service_registered: "服务已注册",
+};
+
+function capabilityReasonLabel(reason: string) {
+  const exact = CAPABILITY_REASON_LABELS[reason];
+  if (exact) return exact;
+  if (reason.startsWith("plugin_initialization_failed")) return "插件初始化失败";
+  return "";
+}
+
 type OverviewPageProps = {
   capabilityState?: CapabilityLoadState;
   accessScope?: "tenant" | "group";
@@ -88,21 +110,28 @@ type OverviewPageProps = {
 function RecoveryActionLink({
   action,
   onRetry,
+  surface = "dark",
 }: {
   action: CapabilityRecoveryAction;
   onRetry: () => void;
+  surface?: "dark" | "paper";
 }) {
+  const className = surface === "paper" ? "button button-secondary button-compact" : "launch-action";
+  const adminMark = action.requires_admin ? (
+    <span className={surface === "paper" ? "pill pill-muted" : "admin-chip"}>管理员</span>
+  ) : null;
   if (action.type === "retry") {
     return (
-      <button className="launch-action" type="button" onClick={onRetry}>
+      <button className={className} type="button" onClick={onRetry}>
         {action.label}
+        {adminMark}
       </button>
     );
   }
   return (
-    <Link className="launch-action" to={action.target}>
+    <Link className={className} to={action.target}>
       {action.label}
-      {action.requires_admin && <span>管理员</span>}
+      {adminMark}
     </Link>
   );
 }
@@ -164,12 +193,13 @@ function CapabilityDiagnostic({
   onRetry: () => void;
 }) {
   const dependencyIssues = capability.dependencies.filter((item) => item.state !== "ready");
+  const reasonLabel = capabilityReasonLabel(capability.status_reason);
   return (
     <article className={`capability-diagnostic is-${capability.health}`}>
       <div>
         <span className="capability-diagnostic-source">能力检查</span>
         <h3>{capability.label}</h3>
-        <p>{capability.status_reason}</p>
+        {reasonLabel ? <p>{reasonLabel}</p> : null}
       </div>
       <div className="capability-diagnostic-state">
         <span>{CAPABILITY_STATE_LABELS[capability.health]}</span>
@@ -182,7 +212,9 @@ function CapabilityDiagnostic({
           {dependencyIssues.map((dependency) => (
             <li key={dependency.id}>
               <strong>{dependency.required ? "必需" : "可选"}</strong>
-              <span>{dependency.reason}</span>
+              {capabilityReasonLabel(dependency.reason) ? (
+                <span>{capabilityReasonLabel(dependency.reason)}</span>
+              ) : null}
               <TechnicalDetails summary="查看依赖标识" value={dependency.id} />
             </li>
           ))}
@@ -195,6 +227,7 @@ function CapabilityDiagnostic({
               key={`${action.type}-${action.target}`}
               action={action}
               onRetry={onRetry}
+              surface="paper"
             />
           ))}
         </div>
@@ -240,8 +273,18 @@ export function OverviewPage({
   const checklistStorageKey = `agent-console:launch-checklist:v1:${config.tenantId || "default"}`;
 
   useEffect(() => {
-    setChecklistDismissed(window.localStorage.getItem(checklistStorageKey) === "dismissed");
-  }, [checklistStorageKey]);
+    const stored = window.localStorage.getItem(checklistStorageKey);
+    if (stored === "dismissed") {
+      setChecklistDismissed(true);
+      return;
+    }
+    if (stored === "open") {
+      setChecklistDismissed(false);
+      return;
+    }
+    const steps = capabilityState.data?.onboarding?.steps || [];
+    setChecklistDismissed(steps.length > 0 && steps.every((step) => step.state === "ready"));
+  }, [capabilityState.data?.onboarding, checklistStorageKey]);
 
   const loadOverview = async () => {
     setLoading(true);
@@ -339,13 +382,12 @@ export function OverviewPage({
           <div>
             <p className="section-kicker">上线顺序</p>
             <strong>上线清单已收起</strong>
-            <span>系统仍会按租户能力过滤入口，不会把不可用功能伪装成可用。</span>
           </div>
           <button
             className="button button-secondary"
             type="button"
             onClick={() => {
-              window.localStorage.removeItem(checklistStorageKey);
+              window.localStorage.setItem(checklistStorageKey, "open");
               setChecklistDismissed(false);
             }}
           >
@@ -362,7 +404,6 @@ export function OverviewPage({
             <div>
               <p className="section-kicker">上线顺序</p>
               <h2>正在读取租户能力</h2>
-              <p>导航与首启步骤会以服务端能力注册表为准。</p>
             </div>
             <span className="launch-orbit" aria-hidden="true" />
           </div>
@@ -389,11 +430,11 @@ export function OverviewPage({
               <h2 id="launch-checklist-title">
                 {groupScoped ? "从授权群到安全参与" : "从依赖检查到正式参与"}
               </h2>
-              <p>
-                {groupScoped
-                  ? "这里只展示当前身份可管理的群聊能力，不暴露租户级运行配置。"
-                  : <>这是租户 <code>{capabilityState.data?.tenant_id}</code> 的服务端状态，按顺序完成后再让机器人加入真实群聊。</>}
-              </p>
+              {!groupScoped ? (
+                <p>
+                  这是租户 <code>{capabilityState.data?.tenant_id}</code> 的当前状态，按顺序完成后再让机器人加入真实群聊。
+                </p>
+              ) : null}
             </div>
             <div
               className={`launch-readiness is-${checklist.steps.length ? checklist.state : "empty"}`}
@@ -426,11 +467,10 @@ export function OverviewPage({
           ) : (
             <div className="launch-checklist-empty" role="status">
               <strong>暂无上线步骤</strong>
-              <p>服务端未返回可执行的上线清单；这不表示所有能力已就绪，请刷新能力检查或联系管理员确认能力注册。</p>
+              <p>当前没有可执行的上线步骤。</p>
             </div>
           )}
           <div className="launch-checklist-footer">
-            <span>状态由服务端计算；收起清单不会改变任何运行配置。</span>
             <button
               type="button"
               onClick={() => {
@@ -449,7 +489,7 @@ export function OverviewPage({
           <PageHeader
             eyebrow="群聊工作区"
             title="授权群工作台"
-            description="从已授权群进入参与策略、消息演练和成员知识；平台配置、依赖拓扑与全局运维入口不会出现在此身份下。"
+            description="从已授权群进入参与策略、消息演练和成员知识。"
           />
           <h2 id="group-workspace-title" className="sr-only">授权群工作台入口</h2>
           <div className="status-grid">
@@ -476,6 +516,20 @@ export function OverviewPage({
           eyebrow="系统"
           title="后端运行概览"
           description="查看服务接口、插件路由和关键依赖状态，确认控制台与服务端连接是否正常。"
+          actions={
+            <div className="action-row">
+              <button
+                className="button button-primary"
+                onClick={() => void loadOverview()}
+                disabled={loading}
+              >
+                {loading ? "刷新中..." : "刷新状态"}
+              </button>
+              <a className="button button-secondary" href={apiDocumentUrl(config, "/docs")} target="_blank" rel="noreferrer">
+                接口文档
+              </a>
+            </div>
+          }
         />
         {errorEntries.length > 0 && (
           <div className="overview-degraded-notice" role="status">
@@ -493,21 +547,6 @@ export function OverviewPage({
             </ul>
           </div>
         )}
-        <div className="action-row">
-          <button
-            className="button button-primary"
-            onClick={() => void loadOverview()}
-            disabled={loading}
-          >
-            {loading ? "刷新中..." : "刷新状态"}
-          </button>
-          <a className="button button-secondary" href={apiDocumentUrl(config, "/docs")} target="_blank" rel="noreferrer">
-            交互式接口文档
-          </a>
-          <a className="button button-secondary" href={apiDocumentUrl(config, "/redoc")} target="_blank" rel="noreferrer">
-            备用接口文档
-          </a>
-        </div>
         <div className="status-grid">
           <StatusTile label="运行健康" value={serviceStateLabel(data?.health?.status, Boolean(errors.health))} />
           <StatusTile label="启动就绪" value={serviceStateLabel(data?.ready?.status, Boolean(errors.ready))} />
@@ -527,7 +566,9 @@ export function OverviewPage({
             }
           />
         </div>
-        <ul className="overview-check-meta" aria-label="检查更新时间与恢复动作">
+        <details className="overview-check-meta-wrap">
+          <summary>检查记录</summary>
+          <ul className="overview-check-meta" aria-label="检查更新时间与恢复动作">
           {(Object.keys(OVERVIEW_CHECK_LABELS) as OverviewCheckKey[]).map((key) => (
             <li key={key}>
               <span>{OVERVIEW_CHECK_LABELS[key]}</span>
@@ -544,6 +585,7 @@ export function OverviewPage({
             </li>
           ))}
         </ul>
+        </details>
       </section>
 
       <section className="panel panel-scroll">
@@ -553,10 +595,10 @@ export function OverviewPage({
             <h2>插件与适配器摘要</h2>
           </div>
         </div>
-        <p>
+        <p className="muted-copy">
           {pluginInformationUnavailable
             ? "插件信息暂不可用，请查看上方原因。"
-            : `已发现 ${data?.pluginSummary?.plugins?.length || 0} 个插件、${data?.pluginSummary?.channels?.length || 0} 个已声明通道；已声明不代表已经建立平台连接。`}
+            : `已发现 ${data?.pluginSummary?.plugins?.length || 0} 个插件，已声明 ${data?.pluginSummary?.channels?.length || 0} 个通道。`}
         </p>
         <TechnicalDetails
           summary="查看插件与适配器技术清单"
@@ -580,15 +622,12 @@ export function OverviewPage({
                 <span className="section-kicker">能力诊断</span>
                 <strong id="capability-diagnostics-title">能力与依赖诊断</strong>
               </span>
-              <span className="capability-attention-count">
+              <span className={`capability-attention-count${attentionCapabilities.length > 0 ? "" : " is-clear"}`}>
                 {attentionCapabilities.length > 0
                   ? `${attentionCapabilities.length} 项需处理`
                   : "全部就绪"}
               </span>
             </summary>
-            <p className="capability-diagnostics-copy">
-              导航只显示已启用且可用的能力；被隐藏的能力仍保留在这里，并给出明确依赖和恢复入口。
-            </p>
             <div className="capability-diagnostic-grid">
               {(attentionCapabilities.length > 0
                 ? attentionCapabilities
@@ -606,7 +645,7 @@ export function OverviewPage({
       )}
 
       <div className="span-3">
-        <OutputPanel title="系统响应" value={output} />
+        <OutputPanel flush title="系统响应" value={output} />
       </div>
         </>
       )}

--- a/frontend/src/pages/PlaygroundPage.test.tsx
+++ b/frontend/src/pages/PlaygroundPage.test.tsx
@@ -48,8 +48,8 @@ describe("PlaygroundPage", () => {
       </ConsoleConfigProvider>,
     );
 
-    expect(screen.getByText("尚未选择目标群")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "发送模拟消息" })).toBeDisabled();
+    expect(screen.getByRole("heading", { name: "先选择一个已验证群聊" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "发送模拟消息" })).not.toBeInTheDocument();
   });
 
   it("uses the server-side simulator without a browser tenant secret", async () => {

--- a/frontend/src/pages/PlaygroundPage.tsx
+++ b/frontend/src/pages/PlaygroundPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { Alert } from "../components/Alert";
+import { GroupScopeEmpty } from "../components/GroupScopeEmpty";
 import { OutputPanel } from "../components/OutputPanel";
 import { PageHeader } from "../components/PageHeader";
 import { apiRequest, formatJson } from "../lib/api";
@@ -92,24 +92,29 @@ export function PlaygroundPage() {
     }
   };
 
-  return (
+  return !selectedGroupIsVerified ? (
+    <GroupScopeEmpty
+      eyebrow="消息测试"
+      title="群消息入口模拟器"
+      description="从已验证群聊发起一条服务端模拟消息，走真实消息总线、参与决策和回复链路。浏览器不会接触租户签名密钥。"
+    />
+  ) : (
     <div className="page-grid">
-      <section className="panel span-2">
+      <section className="panel span-3">
         <PageHeader
           eyebrow="消息测试"
           title="群消息入口模拟器"
           description="从已验证群聊发起一条服务端模拟消息，走真实消息总线、参与决策和回复链路。浏览器不会接触租户签名密钥。"
         />
-        {!selectedGroupIsVerified && (
-          <Alert variant="warning" title="尚未选择目标群">
-            请先使用页面顶部的群选择器，从后端已同步列表中选择一个群聊。
-          </Alert>
-        )}
-        <div className="form-grid">
+        <p className="page-meta-line">
+          <span>处理方式 <strong>真实异步队列</strong></span>
+          <span>发送身份 <strong>服务端模拟群成员</strong></span>
+        </p>
+        <div className="form-grid page-compose">
           <label className="field span-2">
             <span>模拟群消息</span>
             <textarea
-              rows={7}
+              rows={5}
               value={message}
               onChange={(event) => setMessage(event.target.value)}
               placeholder="例如：@机器人 帮我总结一下刚才的讨论"
@@ -128,38 +133,8 @@ export function PlaygroundPage() {
             {sending ? "正在进入队列…" : "发送模拟消息"}
           </button>
         </div>
+        <OutputPanel flush title="处理结果（技术详情）" value={output} />
       </section>
-
-      <section className="panel">
-        <div className="panel-header">
-          <div>
-            <p className="section-kicker">当前范围</p>
-            <h3>投递上下文</h3>
-          </div>
-        </div>
-        <dl className="context-list">
-          <div>
-            <dt>当前租户</dt>
-            <dd>{config.tenantId || "未认证"}</dd>
-          </div>
-          <div>
-            <dt>目标群聊</dt>
-            <dd>{selectedGroupIsVerified ? config.sessionId : "未选择"}</dd>
-          </div>
-          <div>
-            <dt>处理方式</dt>
-            <dd>真实异步队列</dd>
-          </div>
-          <div>
-            <dt>发送身份</dt>
-            <dd>服务端模拟群成员</dd>
-          </div>
-        </dl>
-      </section>
-
-      <div className="span-3">
-        <OutputPanel title="处理结果（技术详情）" value={output} />
-      </div>
     </div>
   );
 }

--- a/frontend/src/pages/PluginMarketplacePage.tsx
+++ b/frontend/src/pages/PluginMarketplacePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 import { DangerAction } from "../components/DangerAction";
 import { OutputPanel } from "../components/OutputPanel";
@@ -82,6 +83,8 @@ function marketplaceStateLabel(item: MarketplaceItem) {
 
 export function PluginMarketplacePage() {
   const { config } = useConsoleConfig();
+  const [searchParams] = useSearchParams();
+  const selectedPluginName = searchParams.get("plugin")?.trim() || "";
   const { keyFor, clear } = useStableIdempotencyKeys();
   const [data, setData] = useState<MarketplaceResponse | null>(null);
   const [restart, setRestart] = useState<RestartInstructions | null>(null);
@@ -227,12 +230,30 @@ export function PluginMarketplacePage() {
     void loadMarketplace();
   }, [config.apiBaseUrl, config.adminToken]);
 
+  useEffect(() => {
+    if (!selectedPluginName) {
+      return;
+    }
+    const card = document.getElementById(`marketplace-card-${selectedPluginName}`);
+    if (card && typeof card.scrollIntoView === "function") {
+      card.scrollIntoView({
+        block: "nearest",
+        behavior: "smooth",
+      });
+    }
+  }, [selectedPluginName, data?.items.length]);
+
   return (
     <div>
       <PageHeader
         eyebrow="插件市场"
         title="插件市场"
         description="从本地插件清单查看、预览和安装内置插件；安装和卸载只写入状态，重启后生效。"
+        actions={
+          <button className="button button-secondary" onClick={() => void loadMarketplace()} disabled={loading}>
+            {loading ? "刷新中" : "刷新"}
+          </button>
+        }
       />
 
       {restartRequired && (
@@ -253,22 +274,19 @@ export function PluginMarketplacePage() {
         </div>
       )}
 
-      <section className="status-grid">
+      <section className="status-grid page-hero-metrics">
         <StatusTile label="已安装" value={`${installedCount}`} />
         <StatusTile label="可安装" value={`${availableCount}`} />
         <StatusTile label="风险提示" value={`${blockedCount}`} />
       </section>
 
       <section className="page-grid u-mt-5">
-        <div className="panel span-2">
+        <div className="panel span-3">
           <div className="panel-heading-row">
             <div>
               <p className="section-kicker">清单信息</p>
               <h3>本地插件清单</h3>
             </div>
-            <button className="button button-secondary" onClick={() => void loadMarketplace()} disabled={loading}>
-              {loading ? "刷新中" : "刷新"}
-            </button>
           </div>
 
           <div className="plugin-card-grid marketplace-grid">
@@ -278,7 +296,11 @@ export function PluginMarketplacePage() {
               const canUpgrade = item.installed && item.installed_version && item.installed_version !== item.version;
               const preparedChange = pendingChange?.pluginName === item.name ? pendingChange : null;
               return (
-                <article className="plugin-card marketplace-card" key={item.name}>
+                <article
+                  id={`marketplace-card-${item.name}`}
+                  className={`plugin-card marketplace-card ${selectedPluginName === item.name ? "is-selected" : ""}`}
+                  key={item.name}
+                >
                   <div className="plugin-card-header">
                     <div>
                       <strong>{item.display_name}</strong>
@@ -437,9 +459,8 @@ export function PluginMarketplacePage() {
             })}
             {!sortedItems.length && <p className="plugin-card-empty">本地插件清单暂无可用条目。</p>}
           </div>
+          <OutputPanel flush title="插件市场接口响应" value={output} />
         </div>
-
-        <OutputPanel title="插件市场接口响应" value={output} />
       </section>
     </div>
   );

--- a/frontend/src/pages/PluginsPage.tsx
+++ b/frontend/src/pages/PluginsPage.tsx
@@ -13,6 +13,7 @@ export function PluginsPage() {
       <PluginOverviewSection
         data={page.data}
         pluginCards={page.pluginCards}
+        runtime={page.runtime}
         loading={page.loading}
         canRefresh={page.canManage}
         onRefresh={() => void page.refreshSummary()}
@@ -41,6 +42,8 @@ export function PluginsPage() {
       <InstalledPluginsSection
         pluginCards={page.pluginCards}
         runtime={page.runtime}
+        selectedPluginName={page.selectedPluginName}
+        restartRequired={page.restartRequired}
         canManage={page.canManage}
         onSetPluginEnabled={page.setPluginEnabled}
       />

--- a/frontend/src/pages/RepeaterPage.tsx
+++ b/frontend/src/pages/RepeaterPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Alert } from "../components/Alert";
+import { GroupScopeEmpty } from "../components/GroupScopeEmpty";
 import { OutputPanel } from "../components/OutputPanel";
 import { PageHeader } from "../components/PageHeader";
 import { UnsavedChangesGuard } from "../components/UnsavedChangesGuard";
@@ -134,26 +135,43 @@ export function RepeaterPage() {
   }, [loadConfig]);
 
   return (
+    !selectedGroup ? (
+      <GroupScopeEmpty
+        eyebrow="复读策略"
+        title="复读策略"
+        description="按当前已验证群聊配置。复读内容还会经过真实成员数、敏感信息、链接、命令和统一发言预算检查。"
+      />
+    ) : (
     <div className="page-grid">
       <UnsavedChangesGuard when={dirty} />
-      <section className="panel span-2">
+      <section className="panel span-3">
         <PageHeader
           eyebrow="复读策略"
           title="复读策略"
-          description="按当前已验证群聊配置。复读内容还会经过真实成员数、敏感信息、链接、命令和统一发言预算检查。SDK 群消息门禁只由回复策略的一键聚合配置调整。"
+          description="按当前已验证群聊配置冷却与启用；复读仍受真实成员数、敏感信息和发言预算约束。"
+          actions={
+            <div className="action-row">
+              <button className="button button-secondary" type="button" onClick={() => void loadConfig()} disabled={!selectedGroup || status === "loading" || status === "saving"}>
+                重新读取
+              </button>
+              <button className="button button-primary" type="button" onClick={() => void saveConfig()} disabled={!selectedGroup || !etag || !dirty || !draftValid || status === "loading" || status === "saving" || status === "conflict"}>
+                {status === "saving" ? "保存中…" : "保存配置"}
+              </button>
+              <button className="button button-secondary" type="button" onClick={() => void loadEvents()} disabled={!selectedGroup}>
+                查看触发记录
+              </button>
+            </div>
+          }
         />
-        {!selectedGroup ? (
-          <Alert variant="warning" title="尚未选择已验证群聊">选择群聊后才能读取或修改复读策略。</Alert>
-        ) : null}
         {error ? (
           <Alert variant={status === "conflict" ? "warning" : "danger"} title={status === "conflict" ? "版本冲突" : "配置操作失败"}>
             {error}
           </Alert>
         ) : null}
-        <div className="form-grid">
-          <label className="field field-toggle">
+        <div className="repeater-config-grid">
+          <label className="field">
             <span>启用群复读</span>
-            <span className="toggle-chip">
+            <span className="toggle-row">
               <input
                 type="checkbox"
                 checked={draft.enabled}
@@ -189,20 +207,9 @@ export function RepeaterPage() {
           <span className="pill pill-muted">{dirty ? "有未保存修改" : "已同步"}</span>
           <span className="pill pill-muted">版本 {etag || "-"}</span>
         </div>
-        <div className="action-row">
-          <button className="button button-secondary" type="button" onClick={() => void loadConfig()} disabled={!selectedGroup || status === "loading" || status === "saving"}>
-            重新读取
-          </button>
-          <button className="button button-primary" type="button" onClick={() => void saveConfig()} disabled={!selectedGroup || !etag || !dirty || !draftValid || status === "loading" || status === "saving" || status === "conflict"}>
-            {status === "saving" ? "保存中…" : "保存配置"}
-          </button>
-          <button className="button button-secondary" type="button" onClick={() => void loadEvents()} disabled={!selectedGroup}>
-            查看触发记录
-          </button>
-        </div>
+        <OutputPanel flush title="复读触发记录（技术详情）" value={eventsOutput} />
       </section>
-
-      <OutputPanel title="复读触发记录（技术详情）" value={eventsOutput} />
     </div>
+    )
   );
 }

--- a/frontend/src/pages/connections/ConnectionList.tsx
+++ b/frontend/src/pages/connections/ConnectionList.tsx
@@ -59,9 +59,6 @@ export function ConnectionList({
           <p className="section-kicker">连接实例</p>
           <h2 id="connection-list-title">已配置连接</h2>
         </div>
-        <button className="button button-primary button-compact" type="button" onClick={onAdd} disabled={readOnly}>
-          添加连接
-        </button>
       </div>
 
       <div className="connection-list-filters" aria-label="连接筛选">

--- a/frontend/src/pages/connections/ConnectionsPage.tsx
+++ b/frontend/src/pages/connections/ConnectionsPage.tsx
@@ -63,21 +63,21 @@ export function ConnectionsPage() {
   return (
     <div className="page-grid connections-page">
       <section className="panel panel-hero span-3 connections-hero">
-        <div className="connections-hero-heading">
-          <PageHeader
-            eyebrow="消息接入"
-            title="消息平台连接中心"
-            description="统一管理平台适配器、租户连接实例，以及每条连接的配置校验、生命周期和主动探测状态。"
-          />
-          <div className="action-row connections-hero-actions">
-            <button type="button" className="button button-primary" onClick={() => openCreate()} disabled={globallyReadOnly}>
-              添加连接
-            </button>
-            <button type="button" className="button button-secondary" onClick={() => void refreshAll()} disabled={refreshing}>
-              {refreshing ? "刷新中…" : "刷新全部状态"}
-            </button>
-          </div>
-        </div>
+        <PageHeader
+          eyebrow="消息接入"
+          title="消息平台连接中心"
+          description="统一管理平台适配器、租户连接实例，以及每条连接的配置校验、生命周期和主动探测状态。"
+          actions={
+            <div className="action-row connections-hero-actions">
+              <button type="button" className="button button-primary" onClick={() => openCreate()} disabled={globallyReadOnly}>
+                添加连接
+              </button>
+              <button type="button" className="button button-secondary" onClick={() => void refreshAll()} disabled={refreshing}>
+                {refreshing ? "刷新中…" : "刷新全部状态"}
+              </button>
+            </div>
+          }
+        />
 
         <ol className="connection-domain-model" aria-label="消息平台连接的四个管理环节">
           <li>
@@ -97,10 +97,6 @@ export function ConnectionsPage() {
             <div><strong>主动探测</strong><small>仅在适配器支持时验证真实连接能力</small></div>
           </li>
         </ol>
-        <p className="connection-model-note">
-          <strong>边界说明：</strong>插件声明适配能力；创建并校验配置、按需启用，再完成适配器支持的主动探测后，才算真正接入。
-        </p>
-
         <div className="status-grid connections-status-grid" aria-label="连接状态摘要">
           <StatusTile label="健康连接" value={String(stats.healthy)} />
           <StatusTile label="待处理" value={String(stats.attention)} />

--- a/frontend/src/pages/connections/connections.css
+++ b/frontend/src/pages/connections/connections.css
@@ -8,7 +8,7 @@
 
 .connections-hero {
   display: grid;
-  gap: var(--space-5);
+  gap: var(--space-4);
   overflow: hidden;
 }
 
@@ -26,7 +26,11 @@
 }
 
 .connections-hero-heading .page-header {
-  max-width: 760px;
+  flex: 1;
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: 0;
+  max-width: none;
 }
 
 .connections-hero-actions {
@@ -35,69 +39,60 @@
 }
 
 .connection-domain-model {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--space-2-5);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1-5) var(--space-4);
   margin: 0;
   padding: 0;
   list-style: none;
-  counter-reset: none;
 }
 
 .connection-domain-model li {
-  position: relative;
   display: flex;
   min-width: 0;
-  gap: var(--space-2-5);
-  align-items: center;
-  padding: var(--space-3);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: rgba(255, 255, 255, 0.76);
+  gap: var(--space-2);
+  align-items: baseline;
+  padding: 0;
+  border: 0;
+  background: none;
 }
 
 .connection-domain-model li > span {
-  display: grid;
-  flex: 0 0 30px;
-  width: 30px;
-  height: 30px;
-  place-items: center;
-  border-radius: 50%;
-  color: var(--tone-accent-text);
-  background: var(--tone-accent-bg);
+  display: inline;
+  flex: none;
+  width: auto;
+  height: auto;
+  color: var(--accent);
+  background: none;
+  font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
-  font-weight: 800;
-  letter-spacing: 0.04em;
+  font-weight: 700;
+  letter-spacing: 0.06em;
 }
 
 .connection-domain-model li > div {
-  display: grid;
+  display: flex;
   min-width: 0;
-  gap: var(--space-0-5);
+  gap: var(--space-1-5);
+  align-items: baseline;
 }
 
 .connection-domain-model strong {
   color: var(--text);
-  font-size: var(--font-size-base);
-}
-
-.connection-domain-model small {
-  color: var(--text-secondary);
-  font-size: var(--font-size-xs);
-  line-height: 1.4;
-}
-
-.connection-model-note {
-  margin: -6px 0 0;
-  padding: var(--space-2-5) var(--space-3);
-  border-left: 3px solid var(--accent);
-  color: var(--text-secondary);
-  background: rgba(255, 255, 255, 0.54);
   font-size: var(--font-size-sm);
 }
 
-.connection-model-note strong {
-  color: var(--text);
+.connection-domain-model small {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--font-size-2xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connection-model-note {
+  display: none;
 }
 
 .connections-page .connections-status-grid {
@@ -183,10 +178,10 @@
 .connection-adapter-card {
   display: flex;
   min-width: 0;
-  min-height: 176px;
+  min-height: 0;
   flex-direction: column;
-  gap: var(--space-3);
-  padding: var(--space-3-5);
+  gap: var(--space-2-5);
+  padding: var(--space-3);
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: var(--panel-alt);
@@ -215,10 +210,14 @@
 }
 
 .connection-adapter-card > p {
-  flex: 1;
+  flex: none;
   margin: 0;
+  display: -webkit-box;
+  overflow: hidden;
   color: var(--text-secondary);
   font-size: var(--font-size-sm);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .connection-capability-list {
@@ -431,15 +430,15 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--space-2);
-  margin: var(--space-4-5) 0;
+  margin: var(--space-3) 0;
 }
 
 .connection-health-cell {
   display: grid;
   min-width: 0;
-  min-height: 92px;
-  gap: var(--space-0-5);
-  padding: var(--space-2-5);
+  min-height: 0;
+  gap: 2px;
+  padding: var(--space-2) var(--space-2-5);
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: var(--panel-alt);
@@ -456,9 +455,7 @@
 }
 
 .connection-health-cell > small {
-  color: var(--text-muted);
-  font-size: var(--font-size-2xs);
-  line-height: 1.35;
+  display: none;
 }
 
 .connection-health-cell.is-ok {
@@ -657,10 +654,6 @@
 }
 
 @media (max-width: 1120px) {
-  .connection-domain-model {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
   .connection-skeleton-grid,
   .connection-adapter-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -710,7 +703,6 @@
 }
 
 @media (max-width: 680px) {
-  .connection-domain-model,
   .connections-page .connections-status-grid,
   .connection-skeleton-grid,
   .connection-adapter-grid,

--- a/frontend/src/pages/connections/connections.css
+++ b/frontend/src/pages/connections/connections.css
@@ -51,7 +51,7 @@
   gap: var(--space-2-5);
   align-items: center;
   padding: var(--space-3);
-  border: 1px solid var(--color-custom-dbe4f0);
+  border: 1px solid var(--line);
   border-radius: var(--radius);
   background: rgba(255, 255, 255, 0.76);
 }
@@ -63,8 +63,8 @@
   height: 30px;
   place-items: center;
   border-radius: 50%;
-  color: var(--color-indigo-700);
-  background: var(--color-indigo-50);
+  color: var(--tone-accent-text);
+  background: var(--tone-accent-bg);
   font-size: var(--font-size-2xs);
   font-weight: 800;
   letter-spacing: 0.04em;
@@ -166,7 +166,7 @@
 .connection-detail-skeleton > span {
   overflow: hidden;
   border-radius: var(--radius);
-  background: linear-gradient(100deg, var(--color-custom-edf1f6) 20%, var(--color-slate-50) 45%, var(--color-custom-edf1f6) 70%);
+  background: linear-gradient(100deg, var(--color-paper-dim) 20%, var(--color-paper-bright) 45%, var(--color-paper-dim) 70%);
   background-size: 220% 100%;
   animation: connection-shimmer 1.5s ease-in-out infinite;
 }
@@ -318,13 +318,13 @@
 }
 
 .connection-instance-card:hover {
-  border-color: var(--color-indigo-200);
-  background: var(--color-custom-fafaff);
+  border-color: var(--tone-accent-border);
+  background: var(--panel);
 }
 
 .connection-instance-card.is-selected {
   border-color: var(--accent);
-  background: var(--color-custom-f7f7ff);
+  background: var(--tone-accent-bg);
   box-shadow: 0 0 0 2px var(--accent-light);
 }
 
@@ -474,15 +474,15 @@
 }
 
 .connection-health-cell.is-muted {
-  border-top-color: var(--color-slate-400);
+  border-top-color: var(--accent);
 }
 
 .connection-probe-results {
   margin: var(--space-4-5) 0;
   padding: var(--space-3-5);
-  border: 1px solid var(--color-indigo-200);
+  border: 1px solid var(--tone-accent-border);
   border-radius: var(--radius);
-  background: var(--color-custom-fafaff);
+  background: var(--panel);
 }
 
 .connection-probe-results h3,

--- a/frontend/src/pages/connections/connections.css
+++ b/frontend/src/pages/connections/connections.css
@@ -441,9 +441,9 @@
   gap: var(--space-0-5);
   padding: var(--space-2-5);
   border: 1px solid var(--line);
-  border-top-width: 3px;
   border-radius: var(--radius);
   background: var(--panel-alt);
+  box-shadow: inset 3px 0 0 var(--line-strong);
 }
 
 .connection-health-cell > span {
@@ -462,19 +462,19 @@
 }
 
 .connection-health-cell.is-ok {
-  border-top-color: var(--success);
+  box-shadow: inset 3px 0 0 var(--success);
 }
 
 .connection-health-cell.is-warning {
-  border-top-color: var(--color-amber-600);
+  box-shadow: inset 3px 0 0 var(--color-amber-600);
 }
 
 .connection-health-cell.is-danger {
-  border-top-color: var(--danger);
+  box-shadow: inset 3px 0 0 var(--danger);
 }
 
 .connection-health-cell.is-muted {
-  border-top-color: var(--accent);
+  box-shadow: inset 3px 0 0 var(--accent);
 }
 
 .connection-probe-results {

--- a/frontend/src/pages/credits/CreditsWorkspace.tsx
+++ b/frontend/src/pages/credits/CreditsWorkspace.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import { DangerAction } from "../../components/DangerAction";
 import { Alert } from "../../components/Alert";
+import { GroupScopeEmpty } from "../../components/GroupScopeEmpty";
 import { OutputPanel } from "../../components/OutputPanel";
 import { PageHeader } from "../../components/PageHeader";
 import { SearchableSelect } from "../../components/SearchableSelect";
@@ -35,7 +36,6 @@ import {
   formatDelta,
   getReasonLabel,
   getCheckinModeText,
-  getCheckinModeDescription,
   type CreditsConfigDraft,
   configFingerprint,
 } from "./model";
@@ -559,6 +559,16 @@ export function CreditsWorkspace() {
     }
   }, [rosterMembers, transferToUserId]);
 
+  if (!selectedSessionIsGroup) {
+    return (
+      <GroupScopeEmpty
+        eyebrow="积分运营"
+        title="按群积分配置与签到运营"
+        description="对齐旧 wx-bot 的核心体验：按群单独启用和配置积分、按成员查看积分与签到状态、查看排行榜与流水，并管理三种签到模式。"
+      />
+    );
+  }
+
   return (
     <div className="page-grid credits-page">
       <UnsavedChangesGuard when={configDirty} />
@@ -566,16 +576,10 @@ export function CreditsWorkspace() {
         <PageHeader
           eyebrow="积分运营"
           title="按群积分配置与签到运营"
-          description="对齐旧 wx-bot 的核心体验：按群单独启用和配置积分、按成员查看积分与签到状态、查看排行榜与流水，并管理三种签到模式。"
+          description="积分、签到和排行榜只作用于当前已验证群聊。"
         />
 
-        <div className="credits-hero">
-          <p className="muted-copy">
-            {selectedSessionIsGroup
-              ? <>当前已验证群聊：<strong>{effectiveSessionId}</strong>。积分配置、签到模式、排行榜和成员状态都只作用于该群。</>
-              : <>请先使用页面上方的群聊选择器，从后端已验证列表中选择目标群；本页不会接受手工群 ID，也不会回退到默认范围。</>}
-          </p>
-          <div className="summary-grid">
+        <div className="summary-grid page-hero-metrics">
             <div className="summary-card" data-status={enabled ? "ok" : "warning"}>
               <span>插件状态</span>
               <strong>{enabled ? "已启用" : "未启用"}</strong>
@@ -593,23 +597,13 @@ export function CreditsWorkspace() {
               <strong>{getCheckinModeText(checkinMode)}</strong>
             </div>
           </div>
-        </div>
-      </section>
-
-      <section className="panel span-2">
-        <div className="panel-header">
-          <div>
-            <p className="section-kicker">积分配置</p>
-            <h3>群级积分配置</h3>
-          </div>
-        </div>
         <div className="credits-config-layout">
           <div className="form-grid">
             <label className="field">
               <span>启用</span>
               <select value={enabled ? "true" : "false"} onChange={(event) => setEnabled(event.target.value === "true")}>
-                <option value="true">true</option>
-                <option value="false">false</option>
+                <option value="true">开启</option>
+                <option value="false">关闭</option>
               </select>
             </label>
             <label className="field">
@@ -632,6 +626,24 @@ export function CreditsWorkspace() {
                 onChange={(event) => setInitialCredits(Number(event.target.value))}
               />
             </label>
+            <div className="field span-2">
+              <span>签到模式</span>
+              <div className="credits-mode-switch" role="radiogroup" aria-label="签到模式">
+                {CHECKIN_MODE_OPTIONS.map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={checkinMode === item.value}
+                    className={checkinMode === item.value ? "is-active" : undefined}
+                    onClick={() => setCheckinMode(item.value)}
+                  >
+                    <strong>{item.label}</strong>
+                    <small>{item.description}</small>
+                  </button>
+                ))}
+              </div>
+            </div>
             <label className="field">
               <span>签到基础奖励</span>
               <input
@@ -740,59 +752,19 @@ export function CreditsWorkspace() {
               </button>
             </Alert>
           )}
-          <p className="muted-copy">
-            命令权限已经迁到 <Link to="/commands">全局命令中心</Link>。这里仅管理积分与签到模式本身；
-            <code>/sign-in mode 1|2|3</code> 是否可用由命令中心里的管理员和命令清单决定。
-            普通 AI 回复继续走“每次对话扣费”，命令类交互可在“命令积分规则”里按 <code>/command=分值</code> 单独定价；
-            自然语言触发的高德 Agent 按实际工具结果走这三档计费，不需要映射成命令。
-          </p>
+          <details className="credits-help-disclosure">
+            <summary>命令权限与计费说明</summary>
+            <p className="muted-copy">
+              命令权限已经迁到 <Link to="/commands">全局命令中心</Link>。这里仅管理积分与签到模式本身；
+              <code>/sign-in mode 1|2|3</code> 是否可用由命令中心里的管理员和命令清单决定。
+              普通 AI 回复继续走“每次对话扣费”，命令类交互可在“命令积分规则”里按 <code>/command=分值</code> 单独定价；
+              自然语言触发的高德 Agent 按实际工具结果走这三档计费，不需要映射成命令。
+            </p>
+          </details>
         </div>
       </section>
 
-      <section className="panel">
-        <div className="panel-header">
-          <div>
-            <p className="section-kicker">签到</p>
-            <h3>签到模式</h3>
-          </div>
-        </div>
-        <div className="credits-mode-panel">
-          <div className="credits-mode-current">
-            <span>当前模式</span>
-            <strong>{getCheckinModeText(checkinMode)}</strong>
-            <p>{getCheckinModeDescription(checkinMode)}</p>
-          </div>
-          <div className="credits-mode-grid credits-mode-grid-compact">
-            {CHECKIN_MODE_OPTIONS.map((item) => (
-              <button
-                key={item.value}
-                type="button"
-                className={`credits-mode-card${checkinMode === item.value ? " active" : ""}`}
-                onClick={() => setCheckinMode(item.value)}
-              >
-                <strong>{item.label}</strong>
-                <p>{item.description}</p>
-              </button>
-            ))}
-          </div>
-          <div className="credits-meta-list">
-            <div>
-              <span>基础奖励</span>
-              <strong>{dailyCheckin} {creditName}</strong>
-            </div>
-            <div>
-              <span>连签加成</span>
-              <strong>每 7 天 +{streakBonus}</strong>
-            </div>
-            <div>
-              <span>加成上限</span>
-              <strong>最多 +{streakCap}</strong>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="panel span-2">
+      <section className="panel span-3">
         <div className="panel-header">
           <div>
             <p className="section-kicker">成员</p>
@@ -801,18 +773,7 @@ export function CreditsWorkspace() {
         </div>
         <div className="credits-member-layout">
           <div>
-            <div className="form-grid u-mb-3">
-              <label className="field span-2">
-                <span>选择成员</span>
-                <SearchableSelect
-                  value={selectedUserId}
-                  options={memberOptions}
-                  onChange={setSelectedUserId}
-                  placeholder="从当前群成员中选择"
-                  emptyText={selectedSessionIsGroup ? "当前群还没有加载到已验证成员" : "请先选择已验证群聊"}
-                  disabled={!selectedSessionIsGroup || !memberOptions.length}
-                />
-              </label>
+            <div className="member-filter-row">
               <label className="field">
                 <span>成员筛选</span>
                 <input
@@ -821,18 +782,17 @@ export function CreditsWorkspace() {
                   placeholder="按名称或 user_id 过滤下表"
                 />
               </label>
-            </div>
-
-            <div className="action-row">
-              <button className="button button-secondary" onClick={() => void runOps("refresh")} disabled={!selectedSessionIsGroup}>
-                刷新数据
-              </button>
-              <button className="button button-secondary" onClick={() => void loadRosterMembers()} disabled={!selectedSessionIsGroup}>
-                刷新群成员
-              </button>
-              <button className="button button-secondary" onClick={() => void loadCreditsCollections()} disabled={!selectedSessionIsGroup}>
-                刷新积分数据
-              </button>
+              <div className="action-row">
+                <button className="button button-secondary button-compact" onClick={() => void runOps("refresh")} disabled={!selectedSessionIsGroup}>
+                  刷新数据
+                </button>
+                <button className="button button-secondary button-compact" onClick={() => void loadRosterMembers()} disabled={!selectedSessionIsGroup}>
+                  刷新群成员
+                </button>
+                <button className="button button-secondary button-compact" onClick={() => void loadCreditsCollections()} disabled={!selectedSessionIsGroup}>
+                  刷新积分数据
+                </button>
+              </div>
             </div>
 
             <div className="table-scroll credits-table-scroll">
@@ -1193,7 +1153,7 @@ export function CreditsWorkspace() {
         </div>
       </section>
 
-      <section className="panel span-2">
+      <section className="panel span-3">
         <div className="panel-header">
           <div>
             <p className="section-kicker">选中流水</p>
@@ -1234,8 +1194,10 @@ export function CreditsWorkspace() {
         </div>
       </section>
 
-      <OutputPanel title="积分配置响应" value={configOutput} />
-      <OutputPanel title="积分操作响应" value={opsOutput} />
+      <section className="panel span-3">
+        <OutputPanel flush title="积分配置响应" value={configOutput} />
+        <OutputPanel flush title="积分操作响应" value={opsOutput} />
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/group-behavior/ReleaseControlsPanel.tsx
+++ b/frontend/src/pages/group-behavior/ReleaseControlsPanel.tsx
@@ -75,7 +75,7 @@ function ScopeCard({
     setReason("");
   };
   return (
-    <article className="panel panel-subtle release-control-card" aria-label={title}>
+        <article className="release-control-card" aria-label={title}>
       <div className="panel-header">
         <div>
           <p className="section-kicker">{scope === "global" ? "全局发布" : "租户发布"}</p>
@@ -215,7 +215,7 @@ export function ReleaseControlsPanel({
       <p className="muted-copy">
         全局、租户与单群是三个独立资源，各自使用版本令牌与审计记录；最终阶段取最保守值。
       </p>
-      <div className="form-grid">
+      <div className="release-control-grid">
         <ScopeCard
           title="全局发布控制"
           description="平台级紧急停止与最高灰度阶段。没有平台全局权限时保持只读不可用。"

--- a/frontend/src/pages/knowledge/DocumentsWorkspace.tsx
+++ b/frontend/src/pages/knowledge/DocumentsWorkspace.tsx
@@ -4,7 +4,7 @@ import type { DocumentsController } from "./useDocumentsController";
 export function DocumentsWorkspace({ documents }: { documents: DocumentsController }) {
   return (
     <>
-      <section className="panel span-2">
+      <section className="panel span-3">
         <div className="knowledge-workbench">
           <aside className="knowledge-sidebar">
             <div className="panel-header"><div><p className="section-kicker">知识文档</p><h3>知识文档列表</h3></div></div>

--- a/frontend/src/pages/knowledge/FaqWorkspace.tsx
+++ b/frontend/src/pages/knowledge/FaqWorkspace.tsx
@@ -10,7 +10,7 @@ type FaqWorkspaceProps = {
 export function FaqWorkspace({ faq, currentScopeText }: FaqWorkspaceProps) {
   return (
     <>
-      <section className="panel span-2">
+      <section className="panel span-3">
         <div className="knowledge-workbench">
           <aside className="knowledge-sidebar">
             <div className="panel-header"><div><p className="section-kicker">问答列表</p><h3>常见问答列表</h3></div></div>
@@ -98,21 +98,24 @@ export function FaqWorkspace({ faq, currentScopeText }: FaqWorkspaceProps) {
                 disabled={!faq.selected}
               />
             </div>
+            <FaqPreviewPanel faq={faq} />
           </div>
         </div>
       </section>
-      <FaqPreviewPanel faq={faq} />
     </>
   );
 }
 
 function FaqPreviewPanel({ faq }: { faq: FaqController }) {
   return (
-    <section className="panel">
-      <div className="panel-header"><div><p className="section-kicker">命中预览</p><h3>问答命中测试台</h3></div></div>
+    <details className="knowledge-preview-disclosure">
+      <summary>
+        <span className="section-kicker">命中预览</span>
+        <strong>问答命中测试台</strong>
+      </summary>
       <label className="field">
         <span>测试问题</span>
-        <textarea rows={5} value={faq.testQuery} onChange={(event) => faq.setTestQuery(event.target.value)} placeholder="输入一条真实用户问题，检查会命中哪条 FAQ" />
+        <textarea rows={4} value={faq.testQuery} onChange={(event) => faq.setTestQuery(event.target.value)} placeholder="输入一条真实用户问题，检查会命中哪条 FAQ" />
       </label>
       <div className="action-row"><button className="button button-primary" onClick={() => void faq.runPreview()}>执行测试</button></div>
       {faq.preview ? faq.preview.matched ? (
@@ -126,6 +129,6 @@ function FaqPreviewPanel({ faq }: { faq: FaqController }) {
         </div>
       ) : <div className="admin-notice">当前问题没有命中 FAQ，会继续走后续 FAQ miss 流程。</div>
         : <div className="admin-notice">这里会展示 FAQ 命中测试结果，包括命中的问题、范围和最终回复。</div>}
-    </section>
+    </details>
   );
 }

--- a/frontend/src/pages/knowledge/ImportWorkspace.tsx
+++ b/frontend/src/pages/knowledge/ImportWorkspace.tsx
@@ -12,7 +12,7 @@ export function ImportWorkspace({ importer, currentScopeText }: ImportWorkspaceP
   ).length;
   return (
     <>
-      <section className="panel span-2">
+      <section className="panel span-3">
         <div className="knowledge-workbench">
           <ImportSource importer={importer} currentScopeText={currentScopeText} />
           <div className="knowledge-editor">

--- a/frontend/src/pages/knowledge/KnowledgeHeader.tsx
+++ b/frontend/src/pages/knowledge/KnowledgeHeader.tsx
@@ -14,7 +14,7 @@ export function KnowledgeHeader({ scope, faqCount, documentCount }: KnowledgeHea
       <PageHeader
         eyebrow="知识运营"
         title="FAQ / 知识库运营"
-        description="FAQ 做短问短答，知识库做长文本沉淀。当前界面按作用域管理，并支持 FAQ 命中测试。"
+        description="FAQ 做短问短答，知识库做长文本沉淀。按作用域管理，并支持 FAQ 命中测试。"
       />
       <div className="knowledge-scope-bar">
         <div className="knowledge-scope-controls">

--- a/frontend/src/pages/memory/DebugOutputs.tsx
+++ b/frontend/src/pages/memory/DebugOutputs.tsx
@@ -23,17 +23,17 @@ export function DebugOutputs({
 }: DebugOutputsProps) {
   return (
     <>
-      <OutputPanel title="群会话 / 成员响应" value={meta} />
-      <OutputPanel title="全局身份记忆响应" value={identity} />
-      <OutputPanel title="会话记忆响应" value={session} />
+      <OutputPanel flush title="群会话 / 成员响应" value={meta} />
+      <OutputPanel flush title="全局身份记忆响应" value={identity} />
+      <OutputPanel flush title="会话记忆响应" value={session} />
       <div className="admin-notice admin-notice-warning">
         技术详情：用于排障时查看状态、计数、ID 和字段名；不提供聊天正文导出。
       </div>
-      <OutputPanel title="单条记忆原始元数据" value={memoryItems} />
-      <OutputPanel title="画像候选原始元数据" value={profileEnrichment} />
-      <OutputPanel title="抽取任务原始元数据" value={extractionJobs} />
-      <OutputPanel title="记忆图谱原始元数据" value={memoryGraph} />
-      <OutputPanel title="运行时 / 回填原始元数据" value={runtime} />
+      <OutputPanel flush title="单条记忆原始元数据" value={memoryItems} />
+      <OutputPanel flush title="画像候选原始元数据" value={profileEnrichment} />
+      <OutputPanel flush title="抽取任务原始元数据" value={extractionJobs} />
+      <OutputPanel flush title="记忆图谱原始元数据" value={memoryGraph} />
+      <OutputPanel flush title="运行时 / 回填原始元数据" value={runtime} />
     </>
   );
 }

--- a/frontend/src/pages/memory/MemoryWorkspace.tsx
+++ b/frontend/src/pages/memory/MemoryWorkspace.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { GroupScopeEmpty } from "../../components/GroupScopeEmpty";
 import { PageHeader } from "../../components/PageHeader";
-import { SearchableSelect } from "../../components/SearchableSelect";
 import { TabList } from "../../components/Tabs";
 import { UnsavedChangesGuard } from "../../components/UnsavedChangesGuard";
 import { apiRequest, formatJson, type MemoryBackfillRequest } from "../../lib/api";
@@ -55,7 +55,6 @@ export function MemoryWorkspace() {
   const {
     config,
     verifiedGroupIds,
-    selectVerifiedGroup,
   } = useConsoleConfig();
   const { keyFor, clear } = useStableIdempotencyKeys();
   const [sessions, setSessions] = useState<WxbotSession[]>([]);
@@ -65,6 +64,7 @@ export function MemoryWorkspace() {
   const [events, setEvents] = useState<MemoryEvent[]>([]);
   const [sessionId, setSessionId] = useState(config.sessionId);
   const [selectedMemberWxid, setSelectedMemberWxid] = useState("");
+  const [memberQuery, setMemberQuery] = useState("");
   const [channel, setChannel] = useState("wechat");
   const [sourceKey, setSourceKey] = useState("wxbot");
   const [userId, setUserId] = useState(config.userId);
@@ -167,15 +167,24 @@ export function MemoryWorkspace() {
       sessions.filter((item) => item.session_id === sessionId && isGroupSession(item) && !backfillSessionSet.has(item.session_id)),
     [backfillSessionSet, sessionId, sessions],
   );
-  const memberOptions = useMemo(
-    () =>
-      members.map((item) => ({
-        value: item.wxid,
-        label: `${getMemberDisplayName(item)} (${item.wxid})`,
-        keywords: [item.wxid, item.name || "", item.alias || "", item.remark || "", item.nick_name || ""],
-      })),
-    [members],
-  );
+  const visibleMembers = useMemo(() => {
+    const query = memberQuery.trim().toLowerCase();
+    if (!query) return members;
+    return members.filter((item) => {
+      const haystack = [
+        item.wxid,
+        item.name,
+        item.alias,
+        item.remark,
+        item.nick_name,
+        getMemberDisplayName(item),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [memberQuery, members]);
   const applyIdentityProfile = useCallback((profile: IdentityProfile) => {
     if (!members.some((item) => item.wxid === profile.user_id)) {
       setIdentityOutput(formatJson({ error: "该档案不属于当前群的已验证成员，未切换记忆对象" }));
@@ -626,6 +635,19 @@ export function MemoryWorkspace() {
     });
   }, []);
 
+  const selectedGroupIsVerified = Boolean(
+    config.sessionId.trim() && verifiedGroupIds.has(config.sessionId.trim()),
+  );
+  if (!selectedGroupIsVerified) {
+    return (
+      <GroupScopeEmpty
+        eyebrow="记忆管理"
+        title="用户记忆管理"
+        description="当前记忆模型分为两层：全局身份记忆按用户 ID 聚合，会话记忆按会话 ID 与用户 ID 覆盖。实时对话继续通过流水线沉淀，历史记忆则通过 SDK 的 /ext/query/read 从微信解密库回填。"
+      />
+    );
+  }
+
   return (
     <div className="page-grid memory-page">
       <UnsavedChangesGuard when={hasUnsavedMemoryChanges} />
@@ -633,7 +655,45 @@ export function MemoryWorkspace() {
         <PageHeader
           eyebrow="记忆管理"
           title="用户记忆管理"
-          description="当前记忆模型分为两层：全局身份记忆按用户 ID 聚合，会话记忆按会话 ID 与用户 ID 覆盖。实时对话继续通过流水线沉淀，历史记忆则通过 SDK 的 /ext/query/read 从微信解密库回填。"
+          description="身份记忆按用户聚合，会话记忆按群与成员覆盖。点名册即可切换记忆对象；群聊请在顶部会话条切换。"
+          actions={
+            <div className="action-row">
+              <button className="button button-secondary button-compact" onClick={() => void loadGroups()}>
+                刷新会话列表
+              </button>
+              <button
+                className="button button-secondary button-compact"
+                onClick={() => void loadMembers()}
+                disabled={!selectedSessionIsGroup}
+              >
+                加载群成员
+              </button>
+              <button
+                className="button button-secondary button-compact"
+                onClick={() => {
+                  if (!sessionId.trim()) {
+                    setRuntimeOutput(formatJson({ error: "请先选择微信会话" }));
+                    return;
+                  }
+                  addBackfillSessions([sessionId.trim()]);
+                }}
+              >
+                加入回填
+              </button>
+              <button
+                className="button button-secondary button-compact"
+                onClick={() => {
+                  if (!groupBackfillCandidates.length) {
+                    setRuntimeOutput(formatJson({ message: "当前没有可追加的群聊会话" }));
+                    return;
+                  }
+                  addBackfillSessions(groupBackfillCandidates.map((item) => item.session_id));
+                }}
+              >
+                批量加入群聊
+              </button>
+            </div>
+          }
         />
         <div className="summary-grid">
           <div className="summary-card" data-status="ok">
@@ -653,39 +713,7 @@ export function MemoryWorkspace() {
             <strong>{runtimeProfile?.imported_message_count ?? 0}</strong>
           </div>
         </div>
-        <div className="data-flow-note">
-          <strong>当前链路</strong>
-          <span>实时消息进入控制台后，会同步更新当前会话短期记忆，并把稳定事实沉淀到全局身份记忆。</span>
-          <span>历史回填不再要求 SDK 新增专用接口，而是由平台调 SDK 的 `/ext/query/read` 自己掌握查询模板和合并逻辑。</span>
-        </div>
-        <div className="form-grid">
-          <label className="field">
-            <span>微信会话</span>
-            <SearchableSelect
-              value={sessionId}
-              onChange={(value) => {
-                selectVerifiedGroup(value);
-              }}
-              options={sessionOptions}
-              placeholder="请选择已验证群聊"
-              searchPlaceholder="搜索群名或群 ID"
-              emptyText="暂无已验证群聊"
-              noResultsText="没有匹配的会话"
-            />
-          </label>
-          <label className="field">
-            <span>群成员</span>
-            <SearchableSelect
-              value={selectedMemberWxid}
-              onChange={setSelectedMemberWxid}
-              options={memberOptions}
-              placeholder="请选择群成员"
-              searchPlaceholder="搜索成员名或 WXID"
-              emptyText="暂无群成员"
-              noResultsText="没有匹配的群成员"
-              disabled={!selectedSessionIsGroup}
-            />
-          </label>
+        <div className="page-ops-bar">
           <label className="field">
             <span>消息渠道</span>
             <select value={channel} onChange={(event) => setChannel(event.target.value)}>
@@ -703,69 +731,22 @@ export function MemoryWorkspace() {
             <span>来源键</span>
             <input value={sourceKey} onChange={(event) => setSourceKey(event.target.value)} />
           </label>
-          <div className="field span-2">
-            <span>当前记忆成员</span>
+          <p className="page-meta-line">
+            <span>记忆对象</span>
             <strong>{selectedMember ? getMemberDisplayName(selectedMember) : "尚未选择"}</strong>
-            <small className="mono">{userId || "仅可从当前群成员名册选择"}</small>
-          </div>
+            <span className="mono">{userId || "点击名册应用"}</span>
+          </p>
         </div>
-        <p className="muted-copy">
-          当前会话类型：
-          <span> {selectedSessionIsGroup ? "群聊" : sessionId ? "私聊" : "-"}</span>
-           。当前页只处理已验证群聊及其成员；跨群或私聊记忆不会在这里被手工并入。
-        </p>
-        <div className="action-row">
-          <button className="button button-secondary" onClick={() => void loadGroups()}>
-            刷新会话列表
-          </button>
-          <button
-            className="button button-secondary"
-            onClick={() => void loadMembers()}
-            disabled={!selectedSessionIsGroup}
-          >
-            加载群成员
-          </button>
-          <button
-            className="button button-primary"
-            onClick={() => {
-              if (!selectedSessionIsGroup) {
-                setMetaOutput(formatJson({ error: "请先选择已验证群聊" }));
-                return;
-              }
-              if (!selectedMember) {
-                setMetaOutput(formatJson({ error: "请先选择群成员" }));
-                return;
-              }
-              setUserId(selectedMember.wxid || "");
-              setMetaOutput(formatJson({ applied: true, mode: "verified_group_member", member: selectedMember }));
-            }}
-          >
-            应用当前选择到记忆对象
-          </button>
-          <button
-            className="button button-secondary"
-            onClick={() => {
-              if (!sessionId.trim()) {
-                setRuntimeOutput(formatJson({ error: "请先选择微信会话" }));
-                return;
-              }
-              addBackfillSessions([sessionId.trim()]);
-            }}
-          >
-            加入回填范围
-          </button>
-          <button
-            className="button button-secondary"
-            onClick={() => {
-              if (!groupBackfillCandidates.length) {
-                setRuntimeOutput(formatJson({ message: "当前没有可追加的群聊会话" }));
-                return;
-              }
-              addBackfillSessions(groupBackfillCandidates.map((item) => item.session_id));
-            }}
-          >
-            批量加入全部群聊
-          </button>
+        <div className="member-filter-row">
+          <label className="field">
+            <span>筛选成员</span>
+            <input
+              value={memberQuery}
+              onChange={(event) => setMemberQuery(event.target.value)}
+              placeholder="按成员名或 WXID 筛选"
+              disabled={!selectedSessionIsGroup}
+            />
+          </label>
         </div>
         <div className="table-scroll member-table-scroll">
           <table>
@@ -778,13 +759,21 @@ export function MemoryWorkspace() {
               </tr>
             </thead>
             <tbody>
-              {members.map((item) => (
-                <tr key={item.wxid}>
+              {visibleMembers.map((item) => (
+                <tr
+                  key={item.wxid}
+                  className={item.wxid === selectedMemberWxid ? "table-row-active" : ""}
+                >
                   <th scope="row">
                     <button
                       type="button"
                       className="memory-graph-row-action"
-                      onClick={() => setSelectedMemberWxid(item.wxid || "")}
+                      onClick={() => {
+                        const wxid = item.wxid || "";
+                        setSelectedMemberWxid(wxid);
+                        setUserId(wxid);
+                        setMetaOutput(formatJson({ applied: true, mode: "verified_group_member", member: item }));
+                      }}
                     >
                       {getMemberDisplayName(item)}
                     </button>
@@ -793,9 +782,9 @@ export function MemoryWorkspace() {
                   <td>{item.msg_count ?? 0}</td>
                 </tr>
               ))}
-              {!members.length && (
+              {!visibleMembers.length && (
                 <tr>
-                  <td colSpan={3}>当前群还没有加载到成员列表</td>
+                  <td colSpan={3}>{members.length ? "没有匹配的成员" : "当前群还没有加载到成员列表"}</td>
                 </tr>
               )}
             </tbody>

--- a/frontend/src/pages/persona/PersonaWorkspace.test.tsx
+++ b/frontend/src/pages/persona/PersonaWorkspace.test.tsx
@@ -1,14 +1,16 @@
-import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { apiBlobRequest, apiRequest } from "../../lib/api";
+import { apiRequest } from "../../lib/api";
 import {
-  personaJobDurationLabel,
-  personaJobRetryLabel,
-  personaJobStageLabel,
-  type PersonaJob,
+  portraitConfidenceLabel,
+  portraitCoverageLabel,
+  portraitJobDurationLabel,
+  portraitJobModeLabel,
+  portraitJobStatusLabel,
+  type PortraitJob,
+  type PortraitRecord,
 } from "./model";
 import { PersonaWorkspace } from "./PersonaWorkspace";
 
@@ -37,22 +39,61 @@ vi.mock("../../state/console-config", async (importOriginal) => {
 });
 
 const apiRequestMock = vi.mocked(apiRequest);
-const apiBlobRequestMock = vi.mocked(apiBlobRequest);
 
-const runningJob: PersonaJob = {
-  id: 7,
+const portraitRecord: PortraitRecord = {
+  id: 3,
+  tenant_id: "default",
+  speaker_id: "wxid-zhang",
+  display_name: "张三",
+  session_id: "room@chatroom",
+  status: "ready",
+  pending_messages: 2,
+  hot_update_enabled: true,
+  updated_at: "2026-08-28T05:00:00Z",
+  portrait: {
+    summary: "爱吃烤鱼的打工人",
+    likes: [{ text: "烤鱼", count: 12 }],
+    voice: [{ text: "短句连发", count: 6 }],
+    confidence: 0.82,
+    coverage: { lines_total: 500, lines_read: 500, complete: true },
+  },
+};
+
+const queuedJob: PortraitJob = {
+  id: 11,
   tenant_id: "default",
   session_id: "room@chatroom",
-  session_name: "产品群",
-  target_user_id: "wxid-zhang",
-  target_name: "张三",
-  status: "running",
-  current_stage: "map_chunks",
-  attempt_count: 2,
-  max_attempts: 3,
-  created_at: "2026-07-21T00:00:00Z",
-  started_at: "2026-07-21T00:00:10Z",
+  speaker_id: "wxid-zhang",
+  speaker_name: "张三",
+  status: "queued",
+  mode: "full",
+  created_at: "2026-08-28T05:00:00Z",
 };
+
+type ApiHandler = (path: string, options?: Record<string, unknown>) => unknown;
+
+function installApi(overrides: Record<string, ApiHandler> = {}, options?: { withPortrait?: boolean }) {
+  apiRequestMock.mockImplementation(async (_config, path, requestOptions) => {
+    for (const [prefix, handler] of Object.entries(overrides)) {
+      if (path === prefix || path.startsWith(prefix)) {
+        return handler(path, requestOptions as Record<string, unknown>);
+      }
+    }
+    if (path === "/plugins/wxbot/admin/roster/groups") {
+      return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
+    }
+    if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
+      return { candidates: [{ wxid: "wxid-zhang", name: "张三", msg_count: 120, has_history: true }] };
+    }
+    if (path === "/plugins/speaker_portrait/jobs") return { items: [] };
+    if (path === "/plugins/persona_extract/profiles") return { items: [] };
+    if (path.startsWith("/plugins/speaker_portrait/portraits/")) {
+      if (options?.withPortrait) return portraitRecord;
+      throw new Error("portrait_not_found");
+    }
+    return {};
+  });
+}
 
 function renderWorkspace() {
   return render(
@@ -62,591 +103,208 @@ function renderWorkspace() {
   );
 }
 
-function installBaseApi(getJobs: () => PersonaJob[]) {
-  apiRequestMock.mockImplementation(async (_config, path) => {
-    if (path === "/plugins/wxbot/admin/roster/groups") {
-      return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-    }
-    if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-      return {
-        candidates: [{ wxid: "wxid-zhang", name: "张三", msg_count: 120, has_history: true }],
-      };
-    }
-    if (path === "/plugins/persona_extract/jobs") return { items: getJobs() };
-    if (path === "/plugins/persona_extract/profiles") return { items: [] };
-    return {};
-  });
-}
-
-describe("persona job presentation", () => {
-  it("localizes chunk progress and reports elapsed time and retries", () => {
-    expect(personaJobStageLabel("map_chunks", {
-      progress: { completed_chunks: 3, total_chunks: 8 },
-    })).toBe("提取分段特征（3/8）");
-    expect(personaJobStageLabel("extract_chunk_4_of_9")).toBe("提取分段 4/9");
-    expect(personaJobDurationLabel({
-      ...runningJob,
-      completed_at: "2026-07-21T00:02:15Z",
-    })).toBe("2 分 5 秒");
-    expect(personaJobRetryLabel(runningJob)).toBe("第 2/3 次（已重试 1 次）");
+describe("portrait presentation helpers", () => {
+  it("labels status, mode, duration, confidence and coverage", () => {
+    expect(portraitJobStatusLabel("queued")).toBe("已排队");
+    expect(portraitJobModeLabel("incremental")).toBe("增量热更新");
+    expect(
+      portraitJobDurationLabel({
+        id: 1,
+        status: "completed",
+        started_at: "2026-08-28T05:00:00Z",
+        finished_at: "2026-08-28T05:02:05Z",
+      }),
+    ).toBe("2 分 5 秒");
+    expect(portraitConfidenceLabel({ confidence: 0.82 })).toBe("82%");
+    expect(
+      portraitCoverageLabel({ coverage: { lines_total: 500, lines_read: 500, complete: true } }),
+    ).toBe("500/500（完整）");
   });
 });
 
-describe("PersonaWorkspace asynchronous jobs", () => {
+describe("PersonaWorkspace portrait flow", () => {
   beforeEach(() => {
     apiRequestMock.mockReset();
-    apiBlobRequestMock.mockReset();
     Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
   });
 
-  it("polls only the active job one request at a time and preserves dirty artifact text", async () => {
-    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
-    let resolvePoll: ((job: PersonaJob) => void) | undefined;
-    installBaseApi(() => [runningJob]);
-    apiRequestMock.mockImplementation(async (_config, path) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return { candidates: [{ wxid: "wxid-zhang", name: "张三", has_history: true }] };
-      }
-      if (path === "/plugins/persona_extract/jobs") return { items: [runningJob] };
-      if (path === "/plugins/persona_extract/profiles") return { items: [] };
-      if (path === "/plugins/persona_extract/jobs/7") {
-        return new Promise<PersonaJob>((resolve) => { resolvePoll = resolve; });
-      }
-      return {};
-    });
-
+  it("loads roster, jobs and profiles for the verified group", async () => {
+    installApi();
     renderWorkspace();
-    await screen.findByRole("button", { name: "7" });
-    const editor = await screen.findByLabelText("技能提示词正文（运行时注入）");
-    fireEvent.change(editor, { target: { value: "我的手工草稿" } });
 
     await waitFor(() => {
-      expect(setTimeoutSpy.mock.calls.some(([, delay]) => delay === 2_000)).toBe(true);
+      expect(screen.getAllByText("wxid-zhang").length).toBeGreaterThan(0);
     });
-    const pollTimers = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 2_000);
-    const pollTimer = pollTimers[pollTimers.length - 1]?.[0] as (() => void);
-    const listCountBeforePoll = apiRequestMock.mock.calls.filter(([, path]) => path === "/plugins/persona_extract/jobs").length;
-    await act(async () => {
-      pollTimer();
-      pollTimer();
-      await Promise.resolve();
+    const calledPaths = apiRequestMock.mock.calls.map(([, path]) => path);
+    expect(calledPaths).toContain("/plugins/speaker_portrait/jobs");
+    expect(calledPaths).toContain("/plugins/persona_extract/profiles");
+  });
+
+  it("creates a portrait job for the selected roster member", async () => {
+    let createdBody: Record<string, unknown> | null = null;
+    installApi({
+      "/plugins/speaker_portrait/jobs": (_path, requestOptions) => {
+        const init = (requestOptions as { init?: RequestInit })?.init;
+        if (init?.method === "POST") {
+          createdBody = JSON.parse(String(init.body || "{}"));
+          return { status: "queued", job: queuedJob };
+        }
+        return { items: [] };
+      },
     });
+    renderWorkspace();
+
     await waitFor(() => {
-      expect(apiRequestMock.mock.calls.filter(([, path]) => path === "/plugins/persona_extract/jobs/7")).toHaveLength(1);
+      expect(screen.getAllByText("wxid-zhang").length).toBeGreaterThan(0);
     });
-    expect(apiRequestMock.mock.calls.filter(([, path]) => path === "/plugins/persona_extract/jobs")).toHaveLength(listCountBeforePoll);
-
     await act(async () => {
-      resolvePoll?.({
-        ...runningJob,
-        status: "completed",
-        current_stage: "completed",
-        completed_at: "2026-07-21T00:02:15Z",
-        artifact: { files: { skill_prompt: "服务端新产物" } },
-      });
-      await Promise.resolve();
+      fireEvent.click(screen.getByRole("button", { name: "创建画像任务" }));
     });
 
-    expect(screen.getByLabelText("技能提示词正文（运行时注入）")).toHaveValue("我的手工草稿");
-  });
-
-  it("pauses while hidden and aborts an in-flight poll during cleanup", async () => {
-    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
-    let pollSignal: AbortSignal | undefined;
-    installBaseApi(() => [runningJob]);
-    apiRequestMock.mockImplementation(async (_config, path, options) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return { candidates: [{ wxid: "wxid-zhang", name: "张三", has_history: true }] };
-      }
-      if (path === "/plugins/persona_extract/jobs") return { items: [runningJob] };
-      if (path === "/plugins/persona_extract/profiles") return { items: [] };
-      if (path === "/plugins/persona_extract/jobs/7") {
-        pollSignal = options?.init?.signal || undefined;
-        return new Promise<PersonaJob>(() => undefined);
-      }
-      return {};
+    await waitFor(() => {
+      expect(createdBody).not.toBeNull();
     });
-
-    const view = renderWorkspace();
-    await screen.findByRole("button", { name: "7" });
-    expect(apiRequestMock.mock.calls.some(([, path]) => path === "/plugins/persona_extract/jobs/7")).toBe(false);
-
-    Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
-    await act(async () => {
-      document.dispatchEvent(new Event("visibilitychange"));
-      await Promise.resolve();
-    });
-    await waitFor(() => expect(pollSignal).toBeDefined());
-    view.unmount();
-    expect(pollSignal?.aborted).toBe(true);
-  });
-
-  it("cancels an active job through the asynchronous cancel endpoint", async () => {
-    installBaseApi(() => [runningJob]);
-    apiRequestMock.mockImplementation(async (_config, path, options) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return { candidates: [{ wxid: "wxid-zhang", name: "张三", has_history: true }] };
-      }
-      if (path === "/plugins/persona_extract/jobs") return { items: [runningJob] };
-      if (path === "/plugins/persona_extract/profiles") return { items: [] };
-      if (path === "/plugins/persona_extract/jobs/7/cancel") {
-        expect(options?.init?.method).toBe("POST");
-        expect(new Headers(options?.init?.headers).get("Idempotency-Key")).toMatch(/^agent-console:/);
-        return {
-          job_id: 7,
-          status: "cancelled",
-          cancel_requested: true,
-          job: { ...runningJob, status: "cancelled", current_stage: "cancelled", cancel_requested: true },
-        };
-      }
-      return {};
-    });
-
-    renderWorkspace();
-    const user = userEvent.setup();
-    await screen.findByRole("button", { name: "7" });
-    await user.click(screen.getByRole("button", { name: "取消" }));
-    await user.click(screen.getByRole("button", { name: "确认取消" }));
-
-    await screen.findByText("任务 #7 已取消。");
-    expect(apiRequestMock.mock.calls.some(([, path]) => path === "/plugins/persona_extract/jobs/7/cancel")).toBe(true);
-  });
-
-  it("reconciles an interrupted create by client_request_id instead of submitting again", async () => {
-    let submitted = false;
-    let recoveredJob: PersonaJob | null = null;
-    let submittedClientRequestId = "";
-    installBaseApi(() => (recoveredJob ? [recoveredJob] : []));
-    apiRequestMock.mockImplementation(async (_config, path, options) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return { candidates: [{ wxid: "wxid-zhang", name: "张三", has_history: true }] };
-      }
-      if (path === "/plugins/persona_extract/profiles") return { items: [] };
-      if (path === "/plugins/persona_extract/jobs" && options?.init?.method === "POST") {
-        submitted = true;
-        const headers = new Headers(options.init.headers);
-        const body = JSON.parse(String(options.init.body)) as { client_request_id: string };
-        submittedClientRequestId = body.client_request_id;
-        expect(body.client_request_id).toBe(headers.get("Idempotency-Key"));
-        recoveredJob = {
-          ...runningJob,
-          status: "pending",
-          current_stage: "queued",
-          client_request_id: body.client_request_id,
-        };
-        throw new TypeError("Failed to fetch");
-      }
-      if (path === "/plugins/persona_extract/jobs") {
-        return { items: submitted && recoveredJob ? [recoveredJob] : [] };
-      }
-      return {};
-    });
-
-    renderWorkspace();
-    const user = userEvent.setup();
-    await user.click(await screen.findByRole("button", { name: "张三" }));
-    await user.click(screen.getByRole("button", { name: "创建并执行蒸馏" }));
-    await user.click(screen.getByRole("button", { name: "确认创建任务" }));
-
-    await screen.findByText("提交响应中断，但已按请求标识核对到任务；无需重复创建。页面将继续跟踪该任务。");
-    expect(submittedClientRequestId).toMatch(/^agent-console:/);
-    expect(apiRequestMock.mock.calls.filter(([, path, options]) => (
-      path === "/plugins/persona_extract/jobs" && options?.init?.method === "POST"
-    ))).toHaveLength(1);
-  });
-
-  it("routes a full extraction to the offline export workflow", async () => {
-    let submittedBody: Record<string, unknown> | null = null;
-    installBaseApi(() => []);
-    apiRequestMock.mockImplementation(async (_config, path, options) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return { candidates: [{ wxid: "wxid-zhang", name: "张三", has_history: true }] };
-      }
-      if (path === "/plugins/persona_extract/profiles") return { items: [] };
-      if (path === "/plugins/persona_extract/jobs") return { items: [] };
-      if (path === "/plugins/persona_extract/offline-exports") {
-        submittedBody = JSON.parse(String(options?.init?.body)) as Record<string, unknown>;
-        return {
-          job_id: 19,
-          accepted: true,
-          job: {
-            ...runningJob,
-            id: 19,
-            status: "pending",
-            current_stage: "queued",
-            mode: "offline_full",
-          },
-        };
-      }
-      return {};
-    });
-
-    renderWorkspace();
-    const user = userEvent.setup();
-    await user.click(await screen.findByRole("button", { name: "张三" }));
-    await user.click(screen.getByRole("checkbox", { name: /全量离线/ }));
-    await user.click(screen.getByRole("button", { name: "准备全量离线包" }));
-    await user.click(screen.getByRole("button", { name: "确认准备离线包" }));
-
-    await waitFor(() => expect(submittedBody).not.toBeNull());
-    expect(submittedBody).toMatchObject({
+    expect(createdBody).toMatchObject({
       tenant_id: "default",
       session_id: "room@chatroom",
-      target_user_id: "wxid-zhang",
+      speaker_id: "wxid-zhang",
+      speaker_name: "张三",
       mode: "full",
     });
-    expect(apiRequestMock.mock.calls.some(([, path]) => (
-      path === "/plugins/persona_extract/offline-exports"
-    ))).toBe(true);
+    expect(await screen.findByText("已排队")).toBeInTheDocument();
   });
 
-  it("uploads only the generated ZIP for an awaiting offline task", async () => {
-    const awaitingJob: PersonaJob = {
-      ...runningJob,
-      id: 23,
-      status: "awaiting_import",
-      current_stage: "export_ready",
-      mode: "offline_full",
-      output_slug: "zhang-san",
-    };
-    let uploadedBody: BodyInit | null | undefined;
-    installBaseApi(() => [awaitingJob]);
-    apiRequestMock.mockImplementation(async (_config, path, options) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return { candidates: [{ wxid: "wxid-zhang", name: "张三", has_history: true }] };
-      }
-      if (path === "/plugins/persona_extract/jobs") return { items: [awaitingJob] };
-      if (path === "/plugins/persona_extract/profiles") return { items: [] };
-      if (path === "/plugins/persona_extract/offline-exports/23/artifact") {
-        uploadedBody = options?.init?.body;
-        return {
-          ...awaitingJob,
-          status: "completed",
-          current_stage: "completed",
-          artifact: { files: { skill_prompt: "# 张三" } },
-        };
-      }
-      return {};
-    });
-
+  it("renders portrait summary and claims when the member has a portrait", async () => {
+    installApi({}, { withPortrait: true });
     renderWorkspace();
-    const user = userEvent.setup();
-    const file = new File(["zip-body"], "output.zip", { type: "application/zip" });
-    await user.click(await screen.findByRole("button", { name: "23" }));
-    await screen.findByText("等待回传");
-    await user.upload(await screen.findByLabelText("上传离线生成结果 ZIP"), file);
-    await user.click(screen.getByRole("button", { name: "上传生成结果" }));
-    await user.click(screen.getByRole("button", { name: "确认上传" }));
 
-    await waitFor(() => expect(uploadedBody).toBe(file));
-    expect(apiRequestMock.mock.calls.some(([, path, options]) => (
-      path === "/plugins/persona_extract/offline-exports/23/artifact"
-      && options?.init?.method === "PUT"
-    ))).toBe(true);
+    expect(await screen.findByText("爱吃烤鱼的打工人")).toBeInTheDocument();
+    expect(screen.getByText(/烤鱼（12 次）/)).toBeInTheDocument();
+    expect(screen.getByText(/82%/)).toBeInTheDocument();
   });
 
-  it("restores the saved persona after the workspace is reloaded", async () => {
-    const xiaohaiProfile = {
-      id: 12,
-      session_id: "room@chatroom",
-      channel: "wechat",
-      source_key: "wxbot",
-      source_label: "产品群",
-      profile_name: "小海",
-      target_user_id: "wxid-xiaohai",
-      target_name: "小海",
-      skill_slug: "xiaohai",
-      prompt_text: "# 小海\n\n说话直接、会接梗。",
-      enabled: true,
-      artifact: {
-        slug: "xiaohai",
-        target: { user_id: "wxid-xiaohai", name: "小海" },
-        files: { skill_prompt: "# 小海\n\n说话直接、会接梗。" },
+  it("previews and applies the compiled reply style", async () => {
+    let applyBody: Record<string, unknown> | null = null;
+    installApi(
+      {
+        "/plugins/speaker_portrait/portraits/wxid-zhang/style": () => ({
+          status: "ok",
+          name: "张三",
+          prompt: "你就是张三。",
+          prompt_chars: 6,
+        }),
+        "/plugins/speaker_portrait/portraits/wxid-zhang/apply-style": (_path, requestOptions) => {
+          const init = (requestOptions as { init?: RequestInit })?.init;
+          applyBody = JSON.parse(String(init?.body || "{}"));
+          return { status: "applied", profile_id: 21, name: "张三", prompt: "你就是张三。", prompt_chars: 6 };
+        },
       },
-    };
-    apiRequestMock.mockImplementation(async (_config, path) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return { candidates: [{ wxid: "wxid-zhang", name: "张三", has_history: true }] };
-      }
-      if (path === "/plugins/persona_extract/jobs") return { items: [] };
-      if (path === "/plugins/persona_extract/profiles") return { items: [xiaohaiProfile] };
-      return {};
-    });
-
+      { withPortrait: true },
+    );
     renderWorkspace();
 
-    expect(await screen.findByLabelText("当前风格技能")).toHaveValue("12");
-    expect(screen.getByLabelText("配置名称")).toHaveValue("小海");
-    expect(screen.getByLabelText("技能标识")).toHaveValue("xiaohai");
-    expect(screen.getByLabelText("技能提示词正文（运行时注入）")).toHaveValue("# 小海\n\n说话直接、会接梗。");
-  });
-
-  it("keeps an explicitly applied distillation target instead of jumping back to the current skill", async () => {
-    const xiaohaiProfile = {
-      id: 12,
-      session_id: "room@chatroom",
-      channel: "wechat",
-      source_key: "wxbot",
-      source_label: "产品群",
-      profile_name: "小海",
-      target_user_id: "wxid-xiaohai",
-      target_name: "小海",
-      skill_slug: "xiaohai",
-      prompt_text: "# 小海\n\n说话直接、会接梗。",
-      enabled: true,
-      artifact: {
-        slug: "xiaohai",
-        target: { user_id: "wxid-xiaohai", name: "小海" },
-        files: { skill_prompt: "# 小海\n\n说话直接、会接梗。" },
-      },
-    };
-    apiRequestMock.mockImplementation(async (_config, path) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return {
-          candidates: [
-            { wxid: "wxid-zhang", name: "张三", has_history: true },
-            { wxid: "wxid-li", name: "李四", has_history: true },
-          ],
-        };
-      }
-      if (path === "/plugins/persona_extract/jobs") return { items: [] };
-      if (path === "/plugins/persona_extract/profiles") return { items: [xiaohaiProfile] };
-      return {};
+    expect(await screen.findByText("爱吃烤鱼的打工人")).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "预览风格提示词" }));
     });
+    expect(await screen.findByDisplayValue("你就是张三。")).toBeInTheDocument();
 
-    renderWorkspace();
-    const user = userEvent.setup();
-    expect(await screen.findByLabelText("配置名称")).toHaveValue("小海");
-
-    await user.click(screen.getByRole("combobox", { name: "群成员候选" }));
-    await user.click(screen.getByRole("option", { name: "李四 (wxid-li)" }));
-    await user.click(screen.getByRole("button", { name: "应用到蒸馏目标" }));
-
-    const targetField = screen.getByText("蒸馏目标成员").closest(".field");
-    expect(targetField).not.toBeNull();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "应用为本群回复风格" }));
+    });
     await waitFor(() => {
-      expect(within(targetField as HTMLElement).getByText("李四")).toBeInTheDocument();
-      expect(within(targetField as HTMLElement).getByText("wxid-li")).toBeInTheDocument();
+      expect(applyBody).not.toBeNull();
     });
-    expect(screen.getByLabelText("配置名称")).toHaveValue("小海");
-    expect(apiRequestMock.mock.calls.filter(([, path]) => path === "/plugins/persona_extract/profiles")).toHaveLength(1);
-  });
-
-  it("saves an existing persona even when its source member is no longer in the group roster", async () => {
-    const xiaohaiProfile = {
-      id: 12,
-      session_id: "room@chatroom",
-      channel: "wechat",
-      source_key: "wxbot",
-      source_label: "产品群",
-      profile_name: "xiaohai",
-      target_user_id: "wxid-xiaohai",
-      target_name: "小海",
-      skill_slug: "xiaohai",
-      prompt_text: "# 小海\n\n说话直接、会接梗。",
-      enabled: true,
-      artifact: {
-        slug: "xiaohai",
-        target: { user_id: "wxid-xiaohai", name: "小海" },
-        files: { skill_prompt: "# 小海\n\n说话直接、会接梗。" },
-      },
-    };
-    let savedBody: Record<string, unknown> | null = null;
-    apiRequestMock.mockImplementation(async (_config, path, options) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return { candidates: [{ wxid: "wxid-zhang", name: "张三", has_history: true }] };
-      }
-      if (path === "/plugins/persona_extract/jobs") return { items: [] };
-      if (path === "/plugins/persona_extract/profiles" && options?.init?.method === "POST") {
-        savedBody = JSON.parse(String(options.init.body)) as Record<string, unknown>;
-        return { ...xiaohaiProfile, ...savedBody };
-      }
-      if (path === "/plugins/persona_extract/profiles") return { items: [xiaohaiProfile] };
-      return {};
-    });
-
-    renderWorkspace();
-    const user = userEvent.setup();
-    await user.selectOptions(await screen.findByLabelText("当前风格技能"), "12");
-    const saveButton = screen.getByRole("button", { name: "保存风格技能" });
-    await waitFor(() => expect(saveButton).toBeEnabled());
-    await user.click(saveButton);
-    await user.click(screen.getByRole("button", { name: "确认保存" }));
-
-    await waitFor(() => expect(savedBody).not.toBeNull());
-    expect(savedBody).toMatchObject({
-      profile_id: 12,
-      session_id: "room@chatroom",
-      profile_name: "xiaohai",
-      target_user_id: "wxid-xiaohai",
-      target_name: "小海",
-      skill_slug: "xiaohai",
-      enabled: true,
-    });
-  });
-
-  it("keeps multiple saved skills and activates the selected one", async () => {
-    const xiaohaiProfile = {
-      id: 12,
-      session_id: "room@chatroom",
-      channel: "wechat",
-      source_key: "wxbot",
-      source_label: "产品群",
-      profile_name: "小海",
-      target_user_id: "wxid-xiaohai",
-      target_name: "小海",
-      skill_slug: "xiaohai",
-      prompt_text: "# 小海\n\n说话直接。",
-      enabled: true,
-      artifact: {
-        slug: "xiaohai",
-        target: { user_id: "wxid-xiaohai", name: "小海" },
-        files: { skill_prompt: "# 小海\n\n说话直接。" },
-      },
-    };
-    const newProfile = {
-      id: 21,
-      session_id: "room@chatroom",
-      channel: "wechat",
-      source_key: "wxbot",
-      source_label: "产品群",
-      profile_name: "新人格",
-      target_user_id: "wxid-new",
-      target_name: "新人格",
-      skill_slug: "new-persona",
-      prompt_text: "# 新人格\n\n说话自然。",
-      enabled: false,
-      artifact: {
-        slug: "new-persona",
-        target: { user_id: "wxid-new", name: "新人格" },
-        files: { skill_prompt: "# 新人格\n\n说话自然。" },
-      },
-    };
-    let profiles = [xiaohaiProfile, newProfile];
-    let activateBody: Record<string, unknown> | null = null;
-    apiRequestMock.mockImplementation(async (_config, path, options) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return { candidates: [{ wxid: "wxid-zhang", name: "张三", has_history: true }] };
-      }
-      if (path === "/plugins/persona_extract/jobs") return { items: [] };
-      if (path === "/plugins/persona_extract/profiles/21/activate") {
-        activateBody = JSON.parse(String(options?.init?.body)) as Record<string, unknown>;
-        profiles = [
-          { ...newProfile, enabled: true },
-          { ...xiaohaiProfile, enabled: false },
-        ];
-        return profiles[0];
-      }
-      if (path === "/plugins/persona_extract/profiles") return { items: profiles };
-      return {};
-    });
-
-    renderWorkspace();
-    const user = userEvent.setup();
-
-    expect(await screen.findByText("当前启用")).toBeInTheDocument();
-    expect(screen.getByText("已保存")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "启用" }));
-    await user.click(screen.getByRole("button", { name: "确认启用" }));
-
-    await waitFor(() => expect(activateBody).toEqual({
+    expect(applyBody).toMatchObject({
       tenant_id: "default",
       session_id: "room@chatroom",
-    }));
-    expect(screen.getByLabelText("当前风格技能")).toHaveValue("21");
-  });
-
-  it("applies a completed persona job after the source member has left the current roster", async () => {
-    const completedJob: PersonaJob = {
-      ...runningJob,
-      id: 19,
-      status: "completed",
-      current_stage: "completed",
-      target_user_id: "wxid-xiaohai",
-      target_name: "小海",
-      output_slug: "xiaohai",
-      result_text: "# 小海\n\n说话自然，会接梗。",
-      artifact: {
-        slug: "xiaohai",
-        target: { user_id: "wxid-xiaohai", name: "小海" },
-        files: { skill_prompt: "# 小海\n\n说话自然，会接梗。" },
-      },
-    };
-    let appliedBody: Record<string, unknown> | null = null;
-    apiRequestMock.mockImplementation(async (_config, path, options) => {
-      if (path === "/plugins/wxbot/admin/roster/groups") {
-        return { sessions: [{ session_id: "room@chatroom", session_name: "产品群", kind: "group" }] };
-      }
-      if (path.includes("/plugins/wxbot/admin/roster/groups/") && path.endsWith("/members")) {
-        return { candidates: [{ wxid: "wxid-zhang", name: "张三", has_history: true }] };
-      }
-      if (path === "/plugins/persona_extract/jobs") return { items: [completedJob] };
-      if (path === "/plugins/persona_extract/profiles/apply-job") {
-        appliedBody = JSON.parse(String(options?.init?.body)) as Record<string, unknown>;
-        return {
-          id: 19,
-          session_id: "room@chatroom",
-          profile_name: "小海",
-          target_user_id: "wxid-xiaohai",
-          target_name: "小海",
-          skill_slug: "xiaohai",
-          prompt_text: completedJob.result_text,
-          artifact: completedJob.artifact,
-          enabled: true,
-        };
-      }
-      if (path === "/plugins/persona_extract/profiles") return { items: [] };
-      return {};
-    });
-
-    renderWorkspace();
-    const user = userEvent.setup();
-    const applyButton = await screen.findByRole("button", { name: "从任务应用" });
-    await waitFor(() => expect(applyButton).toBeEnabled());
-    await user.click(applyButton);
-    await user.click(screen.getByRole("button", { name: "确认应用" }));
-
-    await waitFor(() => expect(appliedBody).not.toBeNull());
-    expect(appliedBody).toMatchObject({
-      session_id: "room@chatroom",
-      job_id: 19,
-      profile_name: "小海",
+      channel: "wechat",
+      source_key: "wxbot",
       enabled: true,
     });
+  });
+
+  it("activates a saved reply-style profile", async () => {
+    let activated = false;
+    installApi({
+      "/plugins/persona_extract/profiles/21/activate": () => {
+        activated = true;
+        return { id: 21, enabled: true, session_id: "room@chatroom" };
+      },
+      "/plugins/persona_extract/profiles": (_path, requestOptions) => {
+        const init = (requestOptions as { init?: RequestInit })?.init;
+        if (init?.method) return {};
+        return {
+          items: [
+            {
+              id: 21,
+              session_id: "room@chatroom",
+              profile_name: "张三",
+              skill_slug: "portrait-wxid-zhang",
+              enabled: false,
+              updated_at: "2026-08-28T05:00:00Z",
+            },
+          ],
+        };
+      },
+    });
+    renderWorkspace();
+
+    expect(await screen.findByText("portrait-wxid-zhang")).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "启用" }));
+    });
+    await waitFor(() => {
+      expect(activated).toBe(true);
+    });
+  });
+
+  it("polls the active portrait job and refreshes portrait and profiles on completion", async () => {
+    vi.useFakeTimers();
+    let pollCount = 0;
+    installApi(
+      {
+        "/plugins/speaker_portrait/jobs/11": () => {
+          pollCount += 1;
+          return { ...queuedJob, status: pollCount >= 2 ? "completed" : "running" };
+        },
+        "/plugins/speaker_portrait/jobs": (_path, requestOptions) => {
+          const init = (requestOptions as { init?: RequestInit })?.init;
+          if (init?.method === "POST") return { status: "queued", job: queuedJob };
+          return { items: [queuedJob] };
+        },
+      },
+      { withPortrait: true },
+    );
+    renderWorkspace();
+
+    // Flush the mount-time roster/job/profile loads so the polling effect
+    // can see the active job and schedule its first tick.
+    await act(async () => {});
+    await act(async () => {});
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+    });
+    expect(pollCount).toBe(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100);
+    });
+    expect(pollCount).toBe(2);
+
+    const portraitFetches = apiRequestMock.mock.calls.filter(([, path]) =>
+      String(path).startsWith("/plugins/speaker_portrait/portraits/wxid-zhang"),
+    );
+    expect(portraitFetches.length).toBeGreaterThanOrEqual(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000);
+    });
+    expect(pollCount).toBe(2);
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/pages/persona/PersonaWorkspace.test.tsx
+++ b/frontend/src/pages/persona/PersonaWorkspace.test.tsx
@@ -6,6 +6,8 @@ import { apiRequest } from "../../lib/api";
 import {
   portraitConfidenceLabel,
   portraitCoverageLabel,
+  portraitFreshness,
+  portraitFreshnessHint,
   portraitJobDurationLabel,
   portraitJobModeLabel,
   portraitJobStatusLabel,
@@ -119,6 +121,28 @@ describe("portrait presentation helpers", () => {
     expect(
       portraitCoverageLabel({ coverage: { lines_total: 500, lines_read: 500, complete: true } }),
     ).toBe("500/500（完整）");
+  });
+
+  it("compares last-distillation coverage against the live roster count", () => {
+    const record: PortraitRecord = {
+      pending_messages: 40,
+      portrait: {
+        confidence: 0.89,
+        coverage: { lines_total: 5656, lines_read: 5656, complete: true },
+      },
+    };
+    const freshness = portraitFreshness(record, 6120);
+    expect(freshness).toMatchObject({
+      distilledRead: 5656,
+      liveTotal: 6120,
+      sourceCount: 6120,
+      pendingCount: 40,
+      behind: true,
+      complete: false,
+    });
+    expect(portraitCoverageLabel(record.portrait, freshness)).toBe("5656/6120（部分）");
+    expect(portraitConfidenceLabel(record.portrait, freshness)).toBe("82%");
+    expect(portraitFreshnessHint(freshness)).toContain("画像尚未跟上最新聊天记录");
   });
 });
 

--- a/frontend/src/pages/persona/PersonaWorkspace.tsx
+++ b/frontend/src/pages/persona/PersonaWorkspace.tsx
@@ -22,6 +22,8 @@ import {
   isGroupSession,
   portraitConfidenceLabel,
   portraitCoverageLabel,
+  portraitFreshness,
+  portraitFreshnessHint,
   portraitJobDurationLabel,
   portraitJobModeLabel,
   portraitJobStatusLabel,
@@ -531,6 +533,7 @@ export function PersonaWorkspace() {
   };
 
   const portraitPayload = portrait?.portrait || null;
+  const freshness = portraitFreshness(portrait, selectedMember?.msg_count);
   const claimSections = PORTRAIT_CLAIM_SECTIONS.map(({ key, label }) => ({
     key,
     label,
@@ -798,13 +801,16 @@ export function PersonaWorkspace() {
               <div className="field">
                 <span>置信度 / 覆盖</span>
                 <strong>
-                  {portraitConfidenceLabel(portraitPayload)} · {portraitCoverageLabel(portraitPayload)}
+                  {portraitConfidenceLabel(portraitPayload, freshness)} · {portraitCoverageLabel(portraitPayload, freshness)}
                 </strong>
+                <small>{portraitFreshnessHint(freshness) || "以当前名册发言数对照上次蒸馏覆盖"}</small>
               </div>
               <div className="field">
-                <span>最近更新</span>
-                <strong>{portrait.updated_at || "-"}</strong>
+                <span>最近蒸馏</span>
+                <strong>{portrait.revision_created_at || portrait.updated_at || "-"}</strong>
                 <small>
+                  {portrait.last_message_at ? `最近发言 ${portrait.last_message_at}` : "尚无新发言时间"}
+                  {" · "}
                   热更新{portrait.hot_update_enabled === false ? "已关闭" : "开启"}
                   {typeof portrait.pending_messages === "number"
                     ? ` · 待处理新消息 ${portrait.pending_messages} 条`

--- a/frontend/src/pages/persona/PersonaWorkspace.tsx
+++ b/frontend/src/pages/persona/PersonaWorkspace.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { DangerAction } from "../../components/DangerAction";
+import { GroupScopeEmpty } from "../../components/GroupScopeEmpty";
 import { OutputPanel } from "../../components/OutputPanel";
 import { PageHeader } from "../../components/PageHeader";
-import { SearchableSelect } from "../../components/SearchableSelect";
 import { apiRequest, formatJson } from "../../lib/api";
 import { useStableIdempotencyKeys } from "../../lib/idempotency";
 import { requireSelectedGroup, useConsoleConfig } from "../../state/console-config";
@@ -58,6 +58,7 @@ export function PersonaWorkspace() {
   const [jobMode, setJobMode] = useState<"full" | "incremental">("full");
   const [styleEnabled, setStyleEnabled] = useState(true);
   const [jobNotice, setJobNotice] = useState("");
+  const [memberQuery, setMemberQuery] = useState("");
 
   const [selectionOutput, setSelectionOutput] = useState('{\n  "status": "waiting"\n}');
   const [jobOutput, setJobOutput] = useState('{\n  "status": "waiting"\n}');
@@ -71,15 +72,24 @@ export function PersonaWorkspace() {
   const selectedSessionIsVerified = Boolean(
     effectiveSessionId && verifiedGroupIds.has(effectiveSessionId),
   );
-  const memberOptions = useMemo(
-    () =>
-      members.map((item) => ({
-        value: item.wxid,
-        label: `${getMemberDisplayName(item)} (${item.wxid})`,
-        keywords: [item.wxid, item.name || "", item.alias || "", item.remark || "", item.nick_name || ""],
-      })),
-    [members],
-  );
+  const visibleMembers = useMemo(() => {
+    const query = memberQuery.trim().toLowerCase();
+    if (!query) return members;
+    return members.filter((item) => {
+      const haystack = [
+        item.wxid,
+        item.name,
+        item.alias,
+        item.remark,
+        item.nick_name,
+        getMemberDisplayName(item),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [memberQuery, members]);
   const selectedMember = members.find((item) => item.wxid === selectedMemberWxid) || null;
   const selectedMemberName = selectedMember ? getMemberDisplayName(selectedMember) : "";
   const pollingJobId = useMemo(
@@ -527,6 +537,16 @@ export function PersonaWorkspace() {
     claims: Array.isArray(portraitPayload?.[key]) ? (portraitPayload?.[key] as Array<Record<string, unknown>>) : [],
   })).filter((section) => section.claims.length > 0);
 
+  if (!selectedSessionIsVerified) {
+    return (
+      <GroupScopeEmpty
+        eyebrow="回复风格"
+        title="人物画像 / 回复风格"
+        description="以说话人画像为唯一蒸馏管线：为群成员构建画像，画像编译成回复风格并应用到本群；画像热更新后，已应用的风格会自动同步。"
+      />
+    );
+  }
+
   return (
     <div className="page-grid persona-page">
       <section className="panel span-2">
@@ -534,49 +554,37 @@ export function PersonaWorkspace() {
           eyebrow="回复风格"
           title="人物画像 / 回复风格"
           description="以说话人画像为唯一蒸馏管线：为群成员构建画像，画像编译成回复风格并应用到本群；画像热更新后，已应用的风格会自动同步。"
+          actions={
+            <div className="action-row">
+              <button className="button button-secondary" onClick={() => void loadSessions()}>
+                刷新群列表
+              </button>
+              <button
+                className="button button-secondary"
+                onClick={() => void loadMembers()}
+                disabled={!selectedSessionIsVerified}
+              >
+                加载群成员
+              </button>
+              <button
+                className="button button-secondary"
+                onClick={() => void loadPortrait()}
+                disabled={!selectedMemberWxid}
+              >
+                读取画像
+              </button>
+            </div>
+          }
         />
-        <div className="form-grid">
-          <div className="field span-2">
-            <span>当前已验证群聊</span>
-            <strong>{selectedSessionIsVerified ? (sessionName || effectiveSessionId) : "尚未选择"}</strong>
-            <small>
-              {selectedSessionIsVerified
-                ? effectiveSessionId
-                : "请从页面上方的后端群聊名册选择；本页不接受手工群 ID。"}
-            </small>
-          </div>
-          <label className="field span-2">
-            <span>群成员候选</span>
-            <SearchableSelect
-              value={selectedMemberWxid}
-              onChange={setSelectedMemberWxid}
-              options={memberOptions}
-              placeholder="请选择群成员"
-              searchPlaceholder="搜索成员名或 WXID"
-              emptyText={selectedSessionIsVerified ? "暂无群成员" : "请先选择已验证群聊"}
-              noResultsText="没有匹配的群成员"
-              disabled={!selectedSessionIsVerified || !memberOptions.length}
+        <div className="member-filter-row">
+          <label className="field">
+            <span>筛选成员</span>
+            <input
+              value={memberQuery}
+              onChange={(event) => setMemberQuery(event.target.value)}
+              placeholder="按成员名或 WXID 筛选"
             />
           </label>
-        </div>
-        <div className="action-row">
-          <button className="button button-secondary" onClick={() => void loadSessions()}>
-            刷新群列表
-          </button>
-          <button
-            className="button button-secondary"
-            onClick={() => void loadMembers()}
-            disabled={!selectedSessionIsVerified}
-          >
-            加载群成员
-          </button>
-          <button
-            className="button button-secondary"
-            onClick={() => void loadPortrait()}
-            disabled={!selectedMemberWxid}
-          >
-            读取画像
-          </button>
         </div>
         <div className="table-scroll member-table-scroll">
           <table>
@@ -591,7 +599,7 @@ export function PersonaWorkspace() {
               </tr>
             </thead>
             <tbody>
-              {members.map((item) => (
+              {visibleMembers.map((item) => (
                 <tr
                   key={item.wxid}
                   className={item.wxid === selectedMemberWxid ? "table-row-active" : ""}
@@ -611,9 +619,11 @@ export function PersonaWorkspace() {
                   <td>{item.has_history ? "可提取" : "无历史"}</td>
                 </tr>
               ))}
-              {!members.length && (
+              {!visibleMembers.length && (
                 <tr>
-                  <td colSpan={5}>当前群还没有加载成员候选</td>
+                  <td colSpan={5}>
+                    {members.length ? "没有匹配的群成员" : "当前群还没有加载成员候选"}
+                  </td>
                 </tr>
               )}
             </tbody>
@@ -626,15 +636,10 @@ export function PersonaWorkspace() {
           <div className="panel-header">
             <div>
               <p className="section-kicker">画像蒸馏</p>
-              <h3>画像任务</h3>
+              <h3>{selectedMemberName ? `${selectedMemberName} 的画像任务` : "画像任务"}</h3>
             </div>
           </div>
           <div className="form-grid">
-            <label className="field">
-              <span>画像目标成员</span>
-              <strong>{selectedMemberName || "尚未选择"}</strong>
-              <small className="mono">{selectedMemberWxid || "仅可从当前群成员名册选择"}</small>
-            </label>
             <label className="field">
               <span>任务模式</span>
               <select
@@ -709,7 +714,6 @@ export function PersonaWorkspace() {
               </tbody>
             </table>
           </div>
-          <OutputPanel title="任务响应" value={jobOutput} />
         </section>
 
         <section className="panel panel-scroll">
@@ -774,11 +778,10 @@ export function PersonaWorkspace() {
               刷新档案
             </button>
           </div>
-          <OutputPanel title="档案响应" value={profileOutput} />
         </section>
       </div>
 
-      <section className="panel span-2">
+      <section className="panel span-3">
         <div className="panel-header">
           <div>
             <p className="section-kicker">画像结果</p>
@@ -844,58 +847,53 @@ export function PersonaWorkspace() {
               : "请先从上方名册选择群成员。"}
           </p>
         )}
-        <OutputPanel title="画像数据" value={portraitOutput} />
-      </section>
-
-      <section className="panel span-2">
-        <div className="panel-header">
-          <div>
-            <p className="section-kicker">画像 → 回复风格</p>
-            <h3>编译并应用回复风格</h3>
+        <div className="persona-style-actions">
+          <p className="muted-copy">
+            风格由画像即时编译（第一人称 COS 提示词），应用后写入本群风格档案并参与群聊回复。
+            {appliedProfile
+              ? ` 当前成员已应用：${appliedProfile.profile_name || appliedProfile.skill_slug}（${appliedProfile.enabled ? "启用中" : "已停用"}）。`
+              : " 当前成员尚未应用回复风格。"}
+          </p>
+          <div className="action-row">
+            <button
+              className="button button-secondary"
+              onClick={() => void previewStyle()}
+              disabled={!selectedMemberWxid || !portrait}
+            >
+              预览风格提示词
+            </button>
+            <label className="toggle-row">
+              <input
+                type="checkbox"
+                checked={styleEnabled}
+                onChange={(event) => setStyleEnabled(event.target.checked)}
+              />
+              <strong>应用后立即启用</strong>
+            </label>
+            <button
+              className="button button-primary"
+              onClick={() => void applyStyle()}
+              disabled={!selectedSessionIsVerified || !selectedMemberWxid || !portrait}
+            >
+              应用为本群回复风格
+            </button>
           </div>
+          {stylePreview?.prompt ? (
+            <label className="field span-2">
+              <span>
+                风格提示词（{stylePreview.name || selectedMemberName || "-"} · {stylePreview.prompt_chars ?? stylePreview.prompt.length} 字）
+              </span>
+              <textarea rows={8} value={stylePreview.prompt} readOnly />
+            </label>
+          ) : null}
         </div>
-        <p className="muted-copy">
-          风格由画像即时编译（第一人称 COS 提示词），应用后写入本群风格档案并参与群聊回复。
-          {appliedProfile
-            ? ` 当前成员已应用：${appliedProfile.profile_name || appliedProfile.skill_slug}（${appliedProfile.enabled ? "启用中" : "已停用"}）。`
-            : " 当前成员尚未应用回复风格。"}
-        </p>
-        <div className="action-row">
-          <button
-            className="button button-secondary"
-            onClick={() => void previewStyle()}
-            disabled={!selectedMemberWxid || !portrait}
-          >
-            预览风格提示词
-          </button>
-          <label className="toggle-chip">
-            <input
-              type="checkbox"
-              checked={styleEnabled}
-              onChange={(event) => setStyleEnabled(event.target.checked)}
-            />
-            <strong>应用后立即启用</strong>
-          </label>
-          <button
-            className="button button-primary"
-            onClick={() => void applyStyle()}
-            disabled={!selectedSessionIsVerified || !selectedMemberWxid || !portrait}
-          >
-            应用为本群回复风格
-          </button>
-        </div>
-        {stylePreview?.prompt ? (
-          <label className="field span-2">
-            <span>
-              风格提示词（{stylePreview.name || selectedMemberName || "-"} · {stylePreview.prompt_chars ?? stylePreview.prompt.length} 字）
-            </span>
-            <textarea rows={12} value={stylePreview.prompt} readOnly />
-          </label>
-        ) : null}
       </section>
 
-      <section className="panel span-2">
-        <OutputPanel title="选择过程" value={selectionOutput} />
+      <section className="panel span-3">
+        <OutputPanel flush title="任务响应" value={jobOutput} />
+        <OutputPanel flush title="档案响应" value={profileOutput} />
+        <OutputPanel flush title="画像数据" value={portraitOutput} />
+        <OutputPanel flush title="选择过程" value={selectionOutput} />
       </section>
     </div>
   );

--- a/frontend/src/pages/persona/PersonaWorkspace.tsx
+++ b/frontend/src/pages/persona/PersonaWorkspace.tsx
@@ -4,8 +4,7 @@ import { DangerAction } from "../../components/DangerAction";
 import { OutputPanel } from "../../components/OutputPanel";
 import { PageHeader } from "../../components/PageHeader";
 import { SearchableSelect } from "../../components/SearchableSelect";
-import { UnsavedChangesGuard } from "../../components/UnsavedChangesGuard";
-import { apiBlobRequest, apiRequest, formatJson, parseJsonInput } from "../../lib/api";
+import { apiRequest, formatJson } from "../../lib/api";
 import { useStableIdempotencyKeys } from "../../lib/idempotency";
 import { requireSelectedGroup, useConsoleConfig } from "../../state/console-config";
 
@@ -14,26 +13,25 @@ import {
   type GroupRosterCandidate,
   type GroupRosterPayload,
   type GroupSessionRosterPayload,
-  type PersonaArtifact,
-  type PersonaJob,
   type PersonaProfile,
-  isGroupSession,
+  type PortraitJob,
+  type PortraitRecord,
+  type PortraitStylePreview,
+  PORTRAIT_CLAIM_SECTIONS,
   getMemberDisplayName,
-  buildSkillFrontmatter,
-  buildDefaultMeta,
-  getArtifactPrompt,
-  personaArtifactModeLabel,
-  personaJobDurationLabel,
-  personaJobRetryLabel,
-  personaJobStageLabel,
-  personaJobStatusLabel,
-  shortJobError,
+  isGroupSession,
+  portraitConfidenceLabel,
+  portraitCoverageLabel,
+  portraitJobDurationLabel,
+  portraitJobModeLabel,
+  portraitJobStatusLabel,
+  shortPortraitJobError,
 } from "./model";
 
-const PERSONA_JOB_POLL_DELAYS = [2_000, 5_000, 10_000, 15_000] as const;
+const PORTRAIT_JOB_POLL_DELAYS = [2_000, 5_000, 10_000, 15_000] as const;
 
-function isActivePersonaJob(job: PersonaJob | null | undefined) {
-  return ["pending", "queued", "running"].includes(String(job?.status || ""));
+function isActivePortraitJob(job: PortraitJob | null | undefined) {
+  return ["queued", "running"].includes(String(job?.status || ""));
 }
 
 function isAbortError(error: unknown) {
@@ -42,71 +40,37 @@ function isAbortError(error: unknown) {
     : error instanceof Error && error.name === "AbortError";
 }
 
-type PersonaJobMutationResponse = {
-  job_id?: number;
-  status?: string;
-  accepted?: boolean;
-  status_url?: string;
-  cancel_requested?: boolean;
-  download_url?: string;
-  job?: PersonaJob;
-};
-
 export function PersonaWorkspace() {
   const { config, verifiedGroupIds } = useConsoleConfig();
   const { keyFor, clear } = useStableIdempotencyKeys();
+
   const [sessions, setSessions] = useState<WxbotSession[]>([]);
   const [members, setMembers] = useState<GroupRosterCandidate[]>([]);
-  const [jobs, setJobs] = useState<PersonaJob[]>([]);
+  const [jobs, setJobs] = useState<PortraitJob[]>([]);
   const [profiles, setProfiles] = useState<PersonaProfile[]>([]);
+  const [portrait, setPortrait] = useState<PortraitRecord | null>(null);
+  const [stylePreview, setStylePreview] = useState<PortraitStylePreview | null>(null);
 
-  const [personaSessionName, setPersonaSessionName] = useState("");
+  const [sessionName, setSessionName] = useState("");
   const [selectedMemberWxid, setSelectedMemberWxid] = useState("");
+  const [daysLimit, setDaysLimit] = useState(90);
+  const [maxMessages, setMaxMessages] = useState(4000);
+  const [jobMode, setJobMode] = useState<"full" | "incremental">("full");
+  const [styleEnabled, setStyleEnabled] = useState(true);
+  const [jobNotice, setJobNotice] = useState("");
 
   const [selectionOutput, setSelectionOutput] = useState('{\n  "status": "waiting"\n}');
-  const [output, setOutput] = useState('{\n  "status": "waiting"\n}');
+  const [jobOutput, setJobOutput] = useState('{\n  "status": "waiting"\n}');
+  const [portraitOutput, setPortraitOutput] = useState('{\n  "status": "waiting"\n}');
   const [profileOutput, setProfileOutput] = useState('{\n  "status": "waiting"\n}');
 
-  const [targetUserId, setTargetUserId] = useState("");
-  const [targetName, setTargetName] = useState("");
-  const [fullExtract, setFullExtract] = useState(false);
-  const [daysLimit, setDaysLimit] = useState(90);
-  const [maxMessages, setMaxMessages] = useState(2000);
-  const [jobId, setJobId] = useState("");
-  const [messages, setMessages] = useState("");
-
-  const [profileId, setProfileId] = useState("");
-  const [profileName, setProfileName] = useState("default");
-  const [profileChannel, setProfileChannel] = useState("wechat");
-  const [profileSourceKey, setProfileSourceKey] = useState("wxbot");
-  const [profileSourceLabel, setProfileSourceLabel] = useState("微信机器人");
-  const [profileEnabled, setProfileEnabled] = useState("true");
-  const [profileSkillSlug, setProfileSkillSlug] = useState("");
-
-  const [artifactMode, setArtifactMode] = useState("manual");
-  const [artifactSkillPrompt, setArtifactSkillPrompt] = useState("");
-  const [artifactSkillMd, setArtifactSkillMd] = useState("");
-  const [artifactPersonaMd, setArtifactPersonaMd] = useState("");
-  const [artifactWorkMd, setArtifactWorkMd] = useState("");
-  const [artifactMetaJson, setArtifactMetaJson] = useState("{\n  \n}");
-  const [artifactKnowledgeText, setArtifactKnowledgeText] = useState("");
-  const [artifactFirstTimestamp, setArtifactFirstTimestamp] = useState("");
-  const [artifactLastTimestamp, setArtifactLastTimestamp] = useState("");
-  const [artifactMessageCount, setArtifactMessageCount] = useState("0");
-  const [profileLoaded, setProfileLoaded] = useState(false);
-  const [loadedProfileFingerprint, setLoadedProfileFingerprint] = useState("");
-  const [profileBaselineRequest, setProfileBaselineRequest] = useState(0);
-  const [profileBaselineCaptured, setProfileBaselineCaptured] = useState(0);
-  const [jobNotice, setJobNotice] = useState("");
-  const [offlineArtifactFile, setOfflineArtifactFile] = useState<File | null>(null);
-  const profileDirtyRef = useRef(false);
-  const artifactEditorDirtyRef = useRef(false);
   const jobRequestRef = useRef<AbortController | null>(null);
-  const offlineArtifactInputRef = useRef<HTMLInputElement | null>(null);
   const autoLoadedSessionRef = useRef("");
 
   const effectiveSessionId = config.sessionId.trim();
-  const selectedSessionIsVerified = Boolean(effectiveSessionId && verifiedGroupIds.has(effectiveSessionId));
+  const selectedSessionIsVerified = Boolean(
+    effectiveSessionId && verifiedGroupIds.has(effectiveSessionId),
+  );
   const memberOptions = useMemo(
     () =>
       members.map((item) => ({
@@ -117,164 +81,40 @@ export function PersonaWorkspace() {
     [members],
   );
   const selectedMember = members.find((item) => item.wxid === selectedMemberWxid) || null;
-  const selectedJob = useMemo(
-    () => jobs.find((item) => String(item.id) === String(jobId || "")) || null,
-    [jobs, jobId],
+  const selectedMemberName = selectedMember ? getMemberDisplayName(selectedMember) : "";
+  const pollingJobId = useMemo(
+    () => String(jobs.find(isActivePortraitJob)?.id || ""),
+    [jobs],
   );
-  const selectedAwaitingImportJob = useMemo(
-    () => (
-      selectedJob?.status === "awaiting_import"
-        ? selectedJob
-        : jobs.find((item) => item.status === "awaiting_import") || null
-    ),
-    [jobs, selectedJob],
-  );
-  const personaDisplayName = (profileName || targetName || profileSkillSlug).trim();
-  const hasSaveablePersonaDraft = Boolean(
-    personaDisplayName && artifactSkillPrompt.trim(),
-  );
-  const pollingJobId = useMemo(() => {
-    if (isActivePersonaJob(selectedJob)) return String(selectedJob?.id || "");
-    return String(jobs.find(isActivePersonaJob)?.id || "");
-  }, [jobs, selectedJob]);
-  const canApplySelectedJob = Boolean(String(jobId || "").trim()) && (!selectedJob || selectedJob.status === "completed");
-
-  const syncArtifactEditors = useCallback(
-    (artifact: PersonaArtifact | null | undefined, fallback?: { promptText?: string; mode?: string; slug?: string }) => {
-      artifactEditorDirtyRef.current = false;
-      const nextArtifact = artifact || null;
-      const nextPrompt = getArtifactPrompt(nextArtifact, fallback?.promptText || "");
-      const nextSlug =
-        nextArtifact?.slug ||
-        fallback?.slug ||
-        (typeof nextArtifact?.meta?.slug === "string" ? nextArtifact.meta.slug : "") ||
-        profileSkillSlug;
-      const nextMode = nextArtifact?.mode || fallback?.mode || "manual";
-      const nextKnowledge = nextArtifact?.knowledge?.messages_text || "";
-      const nextMeta =
-        nextArtifact?.meta && Object.keys(nextArtifact.meta).length
-          ? nextArtifact.meta
-          : buildDefaultMeta({
-              targetName: nextArtifact?.target?.name || targetName,
-              targetUserId: nextArtifact?.target?.user_id || targetUserId,
-              slug: nextSlug,
-              sessionName: personaSessionName,
-              sessionId: effectiveSessionId,
-              messageCount:
-                nextArtifact?.knowledge?.message_count ||
-                (nextKnowledge ? nextKnowledge.split("\n").filter(Boolean).length : 0),
-              firstTimestamp: nextArtifact?.knowledge?.first_timestamp || "",
-              lastTimestamp: nextArtifact?.knowledge?.last_timestamp || "",
-            });
-
-      setArtifactMode(nextMode);
-      setArtifactSkillPrompt(nextPrompt);
-      setArtifactSkillMd(nextArtifact?.files?.["SKILL.md"] || buildSkillFrontmatter(nextSlug, targetName, nextPrompt));
-      setArtifactPersonaMd(nextArtifact?.files?.["persona.md"] || "");
-      setArtifactWorkMd(nextArtifact?.files?.["work.md"] || "");
-      setArtifactMetaJson(formatJson(nextMeta));
-      setArtifactKnowledgeText(nextKnowledge);
-      setArtifactFirstTimestamp(nextArtifact?.knowledge?.first_timestamp || "");
-      setArtifactLastTimestamp(nextArtifact?.knowledge?.last_timestamp || "");
-      setArtifactMessageCount(
-        String(
-          nextArtifact?.knowledge?.message_count ||
-            (nextKnowledge ? nextKnowledge.split("\n").filter(Boolean).length : 0),
-        ),
-      );
-      setProfileSkillSlug(nextSlug);
-    },
-    [effectiveSessionId, personaSessionName, profileSkillSlug, targetName, targetUserId],
-  );
-
-  const hydrateProfileForm = useCallback(
-    (profile: PersonaProfile, options?: { syncJobId?: boolean }) => {
-      setProfileId(String(profile.id || ""));
-      setProfileName(String(profile.profile_name || profile.target_name || "default"));
-      setProfileChannel(String(profile.channel || "wechat"));
-      setProfileSourceKey(String(profile.source_key || "wxbot"));
-      setProfileSourceLabel(String(profile.source_label || personaSessionName || ""));
-      setProfileEnabled(String(Boolean(profile.enabled)));
-      setProfileSkillSlug(String(profile.skill_slug || profile.artifact?.slug || ""));
-      if (options?.syncJobId && profile.job_id != null) {
-        setJobId(String(profile.job_id));
-      }
-      if (profile.target_user_id) {
-        setTargetUserId(String(profile.target_user_id));
-      }
-      if (profile.target_name) {
-        setTargetName(String(profile.target_name));
-      }
-      syncArtifactEditors(profile.artifact, {
-        promptText: profile.prompt_text || "",
-        slug: profile.skill_slug || "",
-      });
-      setProfileBaselineRequest((current) => current + 1);
-    },
-    [personaSessionName, syncArtifactEditors],
-  );
-
-  const hydrateJobSelection = useCallback(
-    (job: PersonaJob, options?: { preserveDirtyArtifact?: boolean }) => {
-      setJobId(String(job.id || ""));
-      setTargetUserId(String(job.target_user_id || ""));
-      setTargetName(String(job.target_name || ""));
-      if (
-        String(job.status || "") === "completed"
-        && !(
-          options?.preserveDirtyArtifact
-          && (profileDirtyRef.current || artifactEditorDirtyRef.current)
-        )
-      ) {
-        syncArtifactEditors(job.artifact, {
-          promptText: job.result_text || "",
-          mode: job.mode || "",
-          slug: job.output_slug || "",
-        });
-      }
-      setOutput(formatJson(job));
-    },
-    [syncArtifactEditors],
-  );
-
-  const mergeJobUpdate = useCallback(
-    (job: PersonaJob, options?: { select?: boolean; preserveDirtyArtifact?: boolean }) => {
-      setJobs((current) => {
-        const found = current.some((item) => String(item.id) === String(job.id));
-        return found
-          ? current.map((item) => (String(item.id) === String(job.id) ? job : item))
-          : [job, ...current];
-      });
-      if (options?.select || String(job.id) === String(jobId || "")) {
-        hydrateJobSelection(job, {
-          preserveDirtyArtifact: options?.preserveDirtyArtifact ?? true,
-        });
-      }
-    },
-    [hydrateJobSelection, jobId],
+  const appliedProfile = useMemo(
+    () =>
+      profiles.find(
+        (item) =>
+          selectedMemberWxid &&
+          (item.target_user_id === selectedMemberWxid ||
+            item.skill_slug === `portrait-${selectedMemberWxid.replace(/_/g, "-")}`),
+      ) || null,
+    [profiles, selectedMemberWxid],
   );
 
   const loadSessions = useCallback(async () => {
     try {
-      const result = await apiRequest<GroupSessionRosterPayload>(config, "/plugins/wxbot/admin/roster/groups", {
-        auth: true,
-      });
+      const result = await apiRequest<GroupSessionRosterPayload>(
+        config,
+        "/plugins/wxbot/admin/roster/groups",
+        { auth: true },
+      );
       const nextSessions = (result.sessions || []).filter(isGroupSession);
       setSessions(nextSessions);
-      if (effectiveSessionId) {
-        const matched = nextSessions.find((item) => item.session_id === effectiveSessionId);
-        setPersonaSessionName(matched?.session_name || "");
-      }
       setSelectionOutput(formatJson({ sessions: nextSessions.slice(0, 50), count: nextSessions.length }));
     } catch (err) {
       setSessions([]);
-      setPersonaSessionName("");
       setSelectionOutput(formatJson({
         error: err instanceof Error ? err.message : "读取权威群列表失败",
         recovery: "请刷新页面上方的已验证群聊列表后重试",
       }));
     }
-  }, [config, effectiveSessionId]);
+  }, [config]);
 
   const loadMembers = useCallback(async () => {
     if (!selectedSessionIsVerified) {
@@ -297,110 +137,84 @@ export function PersonaWorkspace() {
     }
   }, [config, effectiveSessionId, selectedSessionIsVerified]);
 
-  const listJobs = useCallback(async (options?: { hydrateFirst?: boolean; quiet?: boolean }) => {
+  const listJobs = useCallback(async (options?: { quiet?: boolean }) => {
     if (!selectedSessionIsVerified) {
-      if (!options?.quiet) setOutput(formatJson({ error: "请先选择群会话" }));
+      if (!options?.quiet) setJobOutput(formatJson({ error: "请先选择群会话" }));
       setJobs([]);
-      return [] as PersonaJob[];
+      return [] as PortraitJob[];
     }
     try {
-      const result = await apiRequest<{ items?: PersonaJob[] }>(config, "/plugins/persona_extract/jobs", {
-        query: { tenant_id: config.tenantId, session_id: effectiveSessionId },
-      });
+      const result = await apiRequest<{ items?: PortraitJob[] }>(
+        config,
+        "/plugins/speaker_portrait/jobs",
+        { query: { tenant_id: config.tenantId, session_id: effectiveSessionId } },
+      );
       const items = result.items || [];
       setJobs(items);
-      if (items[0] && !jobId && options?.hydrateFirst !== false) {
-        hydrateJobSelection(items[0], { preserveDirtyArtifact: true });
-      }
-      const active = items.find((item) => String(item.id) === String(jobId || "")) || items[0] || null;
-      if (!options?.quiet) setOutput(formatJson(active || result));
+      if (!options?.quiet) setJobOutput(formatJson(result));
       return items;
     } catch (err) {
       if (!options?.quiet) {
         setJobs([]);
-        setOutput(formatJson({ error: err instanceof Error ? err.message : "查询任务失败" }));
+        setJobOutput(formatJson({ error: err instanceof Error ? err.message : "查询画像任务失败" }));
       }
       return null;
     }
-  }, [config, effectiveSessionId, hydrateJobSelection, jobId, selectedSessionIsVerified]);
+  }, [config, effectiveSessionId, selectedSessionIsVerified]);
 
-  const getJob = useCallback(async () => {
-    const scopedJob = jobs.find((item) => String(item.id) === String(jobId));
-    if (!selectedSessionIsVerified || !scopedJob) {
-      setOutput(formatJson({ error: "请先从当前群任务列表选择任务" }));
-      return;
+  const loadPortrait = useCallback(async (speakerId?: string, options?: { quiet?: boolean }) => {
+    const target = String(speakerId || selectedMemberWxid || "").trim();
+    if (!target) {
+      if (!options?.quiet) setPortraitOutput(formatJson({ error: "请先选择群成员" }));
+      setPortrait(null);
+      return null;
     }
-    if (jobRequestRef.current) return;
-    const controller = new AbortController();
-    jobRequestRef.current = controller;
     try {
-      const result = await apiRequest<PersonaJob>(config, `/plugins/persona_extract/jobs/${jobId}`, {
-        init: { signal: controller.signal },
-      });
-      mergeJobUpdate(result, { select: true, preserveDirtyArtifact: false });
+      const result = await apiRequest<PortraitRecord>(
+        config,
+        `/plugins/speaker_portrait/portraits/${encodeURIComponent(target)}`,
+        { query: { tenant_id: config.tenantId } },
+      );
+      setPortrait(result);
+      setStylePreview(null);
+      if (!options?.quiet) setPortraitOutput(formatJson(result));
+      return result;
     } catch (err) {
-      if (!isAbortError(err)) {
-        setOutput(formatJson({ error: err instanceof Error ? err.message : "读取任务失败" }));
+      setPortrait(null);
+      setStylePreview(null);
+      if (!options?.quiet) {
+        const message = err instanceof Error ? err.message : "读取画像失败";
+        setPortraitOutput(formatJson(
+          message.includes("portrait_not_found") || message.includes("404")
+            ? { status: "portrait_not_found", hint: "该成员还没有画像，请先创建画像任务。" }
+            : { error: message },
+        ));
       }
-    } finally {
-      if (jobRequestRef.current === controller) jobRequestRef.current = null;
+      return null;
     }
-  }, [config, jobId, jobs, mergeJobUpdate, selectedSessionIsVerified]);
+  }, [config, selectedMemberWxid]);
 
-  const reconcileSubmittedJob = useCallback(async (
-    clientRequestId: string,
-    fallback?: { jobId: string; previousAttemptCount: number },
-  ) => {
-    const items = await listJobs({ hydrateFirst: false, quiet: true });
-    if (!items) return null;
-    const exact = items.find((item) => item.client_request_id === clientRequestId);
-    const fallbackMatch = fallback
-      ? items.find((item) => (
-          String(item.id) === fallback.jobId
-          && (
-            isActivePersonaJob(item)
-            || Number(item.attempt_count || 0) > fallback.previousAttemptCount
-          )
-        ))
-      : null;
-    const recovered = exact || fallbackMatch || null;
-    if (recovered) {
-      mergeJobUpdate(recovered, { select: true, preserveDirtyArtifact: true });
-    }
-    return recovered;
-  }, [listJobs, mergeJobUpdate]);
-
-  const listProfiles = useCallback(async (options?: { hydrateFirst?: boolean }) => {
+  const listProfiles = useCallback(async (options?: { quiet?: boolean }) => {
     if (!selectedSessionIsVerified) {
-      setProfileOutput(formatJson({ error: "请先选择群会话" }));
+      if (!options?.quiet) setProfileOutput(formatJson({ error: "请先选择群会话" }));
       setProfiles([]);
-      setProfileLoaded(false);
       return;
     }
     try {
-      const result = await apiRequest<{ items?: PersonaProfile[] }>(config, "/plugins/persona_extract/profiles", {
-        query: { tenant_id: config.tenantId, session_id: effectiveSessionId },
-      });
-      const items = result.items || [];
-      setProfiles(items);
-      setProfileLoaded(true);
-      if (items[0] && options?.hydrateFirst !== false) {
-        hydrateProfileForm(items[0], { syncJobId: false });
-      } else if (!items.length) {
-        setProfileId("");
-        setProfileName(targetName || "default");
-        setProfileSkillSlug("");
-        setProfileSourceKey("wxbot");
-        setProfileSourceLabel(personaSessionName || "当前群");
-        setProfileBaselineRequest((current) => current + 1);
-      }
-      setProfileOutput(formatJson(result));
+      const result = await apiRequest<{ items?: PersonaProfile[] }>(
+        config,
+        "/plugins/persona_extract/profiles",
+        { query: { tenant_id: config.tenantId, session_id: effectiveSessionId } },
+      );
+      setProfiles(result.items || []);
+      if (!options?.quiet) setProfileOutput(formatJson(result));
     } catch (err) {
       setProfiles([]);
-      setProfileLoaded(false);
-      setProfileOutput(formatJson({ error: err instanceof Error ? err.message : "读取风格技能失败" }));
+      if (!options?.quiet) {
+        setProfileOutput(formatJson({ error: err instanceof Error ? err.message : "读取风格档案失败" }));
+      }
     }
-  }, [config, effectiveSessionId, hydrateProfileForm, personaSessionName, selectedSessionIsVerified, targetName]);
+  }, [config, effectiveSessionId, selectedSessionIsVerified]);
 
   useEffect(() => {
     void loadSessions();
@@ -408,8 +222,7 @@ export function PersonaWorkspace() {
 
   useEffect(() => {
     const matched = sessions.find((item) => item.session_id === effectiveSessionId);
-    setPersonaSessionName(matched?.session_name || "");
-    setProfileSourceLabel(matched?.session_name || (effectiveSessionId ? "当前群" : ""));
+    setSessionName(matched?.session_name || "");
   }, [effectiveSessionId, sessions]);
 
   useEffect(() => {
@@ -417,11 +230,9 @@ export function PersonaWorkspace() {
     setMembers([]);
     setJobs([]);
     setProfiles([]);
+    setPortrait(null);
+    setStylePreview(null);
     setSelectedMemberWxid("");
-    setTargetUserId("");
-    setTargetName("");
-    setProfileLoaded(false);
-    setLoadedProfileFingerprint("");
   }, [config.tenantId, effectiveSessionId]);
 
   useEffect(() => {
@@ -445,6 +256,15 @@ export function PersonaWorkspace() {
   ]);
 
   useEffect(() => {
+    if (!selectedMemberWxid) {
+      setPortrait(null);
+      setStylePreview(null);
+      return;
+    }
+    void loadPortrait(selectedMemberWxid, { quiet: true });
+  }, [loadPortrait, selectedMemberWxid]);
+
+  useEffect(() => {
     if (!pollingJobId || !selectedSessionIsVerified) return undefined;
 
     let disposed = false;
@@ -462,8 +282,8 @@ export function PersonaWorkspace() {
     const scheduleNext = () => {
       clearTimer();
       if (disposed || document.visibilityState === "hidden") return;
-      const delay = PERSONA_JOB_POLL_DELAYS[Math.min(delayIndex, PERSONA_JOB_POLL_DELAYS.length - 1)];
-      delayIndex = Math.min(delayIndex + 1, PERSONA_JOB_POLL_DELAYS.length - 1);
+      const delay = PORTRAIT_JOB_POLL_DELAYS[Math.min(delayIndex, PORTRAIT_JOB_POLL_DELAYS.length - 1)];
+      delayIndex = Math.min(delayIndex + 1, PORTRAIT_JOB_POLL_DELAYS.length - 1);
       timer = window.setTimeout(() => void poll(), delay);
     };
 
@@ -477,15 +297,24 @@ export function PersonaWorkspace() {
       jobRequestRef.current = controller;
       let shouldContinue = true;
       try {
-        const result = await apiRequest<PersonaJob>(
+        const result = await apiRequest<PortraitJob>(
           config,
-          `/plugins/persona_extract/jobs/${pollingJobId}`,
+          `/plugins/speaker_portrait/jobs/${pollingJobId}`,
           { init: { signal: controller.signal } },
         );
         if (disposed) return;
-        mergeJobUpdate(result, { preserveDirtyArtifact: true });
-        shouldContinue = isActivePersonaJob(result);
+        setJobs((current) =>
+          current.map((item) => (String(item.id) === String(result.id) ? result : item)),
+        );
+        shouldContinue = isActivePortraitJob(result);
         setJobNotice("");
+        if (!shouldContinue) {
+          setJobOutput(formatJson(result));
+          // A finished job may have refreshed the portrait and (via the
+          // backend style sync) any applied reply-style profiles.
+          void loadPortrait(result.speaker_id, { quiet: true });
+          void listProfiles({ quiet: true });
+        }
       } catch (err) {
         if (!isAbortError(err) && !disposed) {
           setJobNotice("任务状态自动刷新暂时失败，页面会继续退避重试；无需重新创建任务。");
@@ -515,123 +344,23 @@ export function PersonaWorkspace() {
       controller?.abort();
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [config, mergeJobUpdate, pollingJobId, selectedSessionIsVerified]);
-
-  const applySelectedMember = () => {
-    if (!selectedMember) {
-      setSelectionOutput(formatJson({ error: "请先选择群成员" }));
-      return;
-    }
-    setTargetUserId(selectedMember.wxid || "");
-    setTargetName(getMemberDisplayName(selectedMember));
-    setSelectionOutput(formatJson({ applied: true, session_id: effectiveSessionId, member: selectedMember }));
-  };
+  }, [config, listProfiles, loadPortrait, pollingJobId, selectedSessionIsVerified]);
 
   const createJob = async () => {
-    if (fullExtract) {
-      await createOfflineExport("full");
-      return;
-    }
     const groupId = requireSelectedGroup(config, verifiedGroupIds);
-    const member = members.find((item) => item.wxid === targetUserId);
+    const member = members.find((item) => item.wxid === selectedMemberWxid);
     if (!member) {
-      const error = new Error("蒸馏目标必须来自当前群的已验证成员名册");
-      setOutput(formatJson({ error: error.message }));
+      const error = new Error("画像目标必须来自当前群的已验证成员名册");
+      setJobOutput(formatJson({ error: error.message }));
       throw error;
     }
-    const intent = `persona:create:${config.tenantId}:${groupId}:${targetUserId}:${daysLimit}:${maxMessages}`;
+    const intent = `portrait:create:${config.tenantId}:${groupId}:${member.wxid}:${jobMode}:${daysLimit}:${maxMessages}`;
     const clientRequestId = keyFor(intent);
     setJobNotice("");
     try {
-      const result = await apiRequest<PersonaJobMutationResponse & {
-        result?: {
-          prompt_text?: string;
-          skill_slug?: string;
-          mode?: string;
-          artifact?: PersonaArtifact;
-        };
-      }>(config, "/plugins/persona_extract/jobs", {
-        auth: true,
-        init: {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Idempotency-Key": clientRequestId,
-          },
-          body: JSON.stringify({
-            client_request_id: clientRequestId,
-            tenant_id: config.tenantId,
-            session_id: groupId,
-            session_name: personaSessionName,
-            connection_id: "legacy-wechat-default",
-            adapter_id: "wxbot",
-            external_session_id: groupId,
-            target_user_id: targetUserId,
-            target_name: targetName,
-            days_limit: daysLimit,
-            max_messages: maxMessages,
-            messages: parseJsonInput(messages, []),
-          }),
-        },
-      });
-      if (result.job_id != null) {
-        setJobId(String(result.job_id));
-      }
-      if (result.job) {
-        mergeJobUpdate(result.job, { select: true, preserveDirtyArtifact: true });
-      }
-      if (result.result?.artifact && !artifactEditorDirtyRef.current) {
-        syncArtifactEditors(result.result.artifact, {
-          promptText: result.result.prompt_text || "",
-          mode: result.result.mode || "",
-          slug: result.result.skill_slug || "",
-        });
-      }
-      if (!result.job) await listJobs({ hydrateFirst: false });
-      setOutput(formatJson(result));
-      setJobNotice(result.accepted === false
-        ? "任务已记录，但执行器暂未接收；请稍后刷新任务状态。"
-        : "任务已进入异步队列，页面会自动刷新当前任务状态。",
-      );
-      clear(intent);
-    } catch (err) {
-      const recovered = await reconcileSubmittedJob(clientRequestId);
-      if (recovered) {
-        setJobNotice("提交响应中断，但已按请求标识核对到任务；无需重复创建。页面将继续跟踪该任务。");
-        setOutput(formatJson({
-          status: "submission_result_reconciled",
-          client_request_id: clientRequestId,
-          job: recovered,
-        }));
-        clear(intent);
-        return;
-      }
-      const message = err instanceof Error ? err.message : "创建蒸馏任务失败";
-      setJobNotice(`提交结果未知（请求标识 ${clientRequestId}）。请先刷新任务核对，不要盲目重复提交。`);
-      setOutput(formatJson({
-        status: "submission_result_unknown",
-        client_request_id: clientRequestId,
-        error: message,
-      }));
-      throw new Error("提交结果未知，系统未核对到对应任务；请先刷新任务列表后再决定是否重试");
-    }
-  };
-
-  const createOfflineExport = async (mode: "full" | "incremental") => {
-    const groupId = requireSelectedGroup(config, verifiedGroupIds);
-    const member = members.find((item) => item.wxid === targetUserId);
-    if (!member) {
-      const error = new Error("离线蒸馏目标必须来自当前群的已验证成员名册");
-      setOutput(formatJson({ error: error.message }));
-      throw error;
-    }
-    const intent = `persona:offline:${mode}:${config.tenantId}:${groupId}:${targetUserId}`;
-    const clientRequestId = keyFor(intent);
-    setJobNotice("");
-    try {
-      const result = await apiRequest<PersonaJobMutationResponse>(
+      const result = await apiRequest<{ status?: string; job?: PortraitJob }>(
         config,
-        "/plugins/persona_extract/offline-exports",
+        "/plugins/speaker_portrait/jobs",
         {
           auth: true,
           init: {
@@ -641,294 +370,98 @@ export function PersonaWorkspace() {
               "Idempotency-Key": clientRequestId,
             },
             body: JSON.stringify({
-              client_request_id: clientRequestId,
               tenant_id: config.tenantId,
               session_id: groupId,
-              session_name: personaSessionName,
+              session_name: sessionName,
+              speaker_id: member.wxid,
+              speaker_name: getMemberDisplayName(member),
               connection_id: "legacy-wechat-default",
-              adapter_id: "wxbot",
               external_session_id: groupId,
-              target_user_id: targetUserId,
-              target_name: targetName,
-              mode,
+              days_limit: daysLimit,
+              max_messages: maxMessages,
+              mode: jobMode,
             }),
           },
         },
       );
-      if (result.job_id != null) setJobId(String(result.job_id));
       if (result.job) {
-        mergeJobUpdate(result.job, { select: true, preserveDirtyArtifact: true });
+        const job = result.job;
+        setJobs((current) => {
+          const found = current.some((item) => String(item.id) === String(job.id));
+          return found
+            ? current.map((item) => (String(item.id) === String(job.id) ? job : item))
+            : [job, ...current];
+        });
       } else {
-        await listJobs({ hydrateFirst: false });
+        await listJobs({ quiet: true });
       }
-      setOutput(formatJson(result));
-      setJobNotice(
-        result.accepted === false
-          ? "离线导出任务已记录，但执行器暂未接收；请稍后刷新。"
-          : mode === "full"
-            ? "正在流式准备全量离线包；就绪后下载到本地处理。"
-            : "正在准备仅含新增消息和旧产物基线的增量包。",
-      );
+      setJobOutput(formatJson(result));
+      setJobNotice("画像任务已进入队列，页面会自动跟踪任务状态；完成后画像和已应用风格会自动刷新。");
       clear(intent);
     } catch (err) {
-      const recovered = await reconcileSubmittedJob(clientRequestId);
-      if (recovered) {
-        setJobNotice("提交响应中断，但已核对到离线导出任务；无需重复创建。");
-        clear(intent);
-        return;
-      }
-      const message = err instanceof Error ? err.message : "创建离线导出任务失败";
-      setOutput(formatJson({ error: message, client_request_id: clientRequestId }));
+      const message = err instanceof Error ? err.message : "创建画像任务失败";
+      setJobOutput(formatJson({ error: message }));
       throw err;
     }
   };
 
-  const downloadOfflineBundle = async (job: PersonaJob) => {
+  const previewStyle = async () => {
+    const target = String(selectedMemberWxid || "").trim();
+    if (!target) {
+      setPortraitOutput(formatJson({ error: "请先选择群成员" }));
+      return;
+    }
     try {
-      const blob = await apiBlobRequest(
+      const result = await apiRequest<PortraitStylePreview>(
         config,
-        `/plugins/persona_extract/offline-exports/${job.id}/download`,
+        `/plugins/speaker_portrait/portraits/${encodeURIComponent(target)}/style`,
+        { query: { tenant_id: config.tenantId } },
       );
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement("a");
-      anchor.href = url;
-      anchor.download = `persona-${job.output_slug || job.target_name || "offline"}-${job.id}.zip`;
-      document.body.appendChild(anchor);
-      anchor.click();
-      anchor.remove();
-      URL.revokeObjectURL(url);
-      setJobNotice("离线包已下载。按包内 PROMPT.md 生成 output/ 四个文件，再压缩 output/ 上传。");
+      setStylePreview(result);
+      setPortraitOutput(formatJson({ status: result.status, name: result.name, prompt_chars: result.prompt_chars }));
     } catch (err) {
-      setOutput(formatJson({ error: err instanceof Error ? err.message : "下载离线包失败" }));
-      throw err;
+      setStylePreview(null);
+      setPortraitOutput(formatJson({ error: err instanceof Error ? err.message : "预览风格失败" }));
     }
   };
 
-  const uploadOfflineArtifact = async () => {
-    if (!selectedAwaitingImportJob) {
-      throw new Error("请先选择一个等待回传的离线任务");
+  const applyStyle = async () => {
+    const groupId = requireSelectedGroup(config, verifiedGroupIds);
+    const target = String(selectedMemberWxid || "").trim();
+    if (!target) {
+      setProfileOutput(formatJson({ error: "请先选择群成员" }));
+      return;
     }
-    if (!offlineArtifactFile) {
-      throw new Error("请选择只包含 output/ 生成结果的 ZIP");
-    }
-    const intent = `persona:offline-import:${config.tenantId}:${selectedAwaitingImportJob.id}:${offlineArtifactFile.name}:${offlineArtifactFile.size}`;
+    const intent = `portrait:apply:${config.tenantId}:${groupId}:${target}:${styleEnabled}`;
     try {
-      const result = await apiRequest<PersonaJob>(
+      const result = await apiRequest<PortraitStylePreview>(
         config,
-        `/plugins/persona_extract/offline-exports/${selectedAwaitingImportJob.id}/artifact`,
+        `/plugins/speaker_portrait/portraits/${encodeURIComponent(target)}/apply-style`,
         {
           auth: true,
           init: {
-            method: "PUT",
+            method: "POST",
             headers: {
-              "Content-Type": offlineArtifactFile.type || "application/zip",
+              "Content-Type": "application/json",
               "Idempotency-Key": keyFor(intent),
             },
-            body: offlineArtifactFile,
+            body: JSON.stringify({
+              tenant_id: config.tenantId,
+              session_id: groupId,
+              session_name: sessionName,
+              channel: "wechat",
+              source_key: "wxbot",
+              enabled: styleEnabled,
+            }),
           },
         },
       );
-      mergeJobUpdate(result, { select: true, preserveDirtyArtifact: false });
-      setOfflineArtifactFile(null);
-      if (offlineArtifactInputRef.current) offlineArtifactInputRef.current.value = "";
-      setJobNotice("离线产物校验通过，任务已完成；现在可以“应用”到当前群。");
-      setOutput(formatJson(result));
-      clear(intent);
-    } catch (err) {
-      setOutput(formatJson({ error: err instanceof Error ? err.message : "上传离线产物失败" }));
-      throw err;
-    }
-  };
-
-  const buildArtifactDraft = () => {
-    let parsedMeta: Record<string, unknown>;
-    try {
-      parsedMeta = artifactMetaJson.trim()
-        ? (JSON.parse(artifactMetaJson) as Record<string, unknown>)
-        : {};
-    } catch (err) {
-      throw new Error(`meta.json 不是合法 JSON：${err instanceof Error ? err.message : "未知错误"}`);
-    }
-
-    const slug = profileSkillSlug || targetUserId || "default";
-    const artifactPersonaName = targetName || personaDisplayName;
-    const skillPrompt = artifactSkillPrompt.trim();
-    const skillMd = (
-      artifactSkillMd.trim()
-      || buildSkillFrontmatter(slug, artifactPersonaName, skillPrompt)
-    ).trim();
-    const messageCount =
-      Number(artifactMessageCount) ||
-      artifactKnowledgeText
-        .split("\n")
-        .map((item) => item.trim())
-        .filter(Boolean).length;
-
-    const meta =
-      Object.keys(parsedMeta).length > 0
-        ? parsedMeta
-        : buildDefaultMeta({
-            targetName: artifactPersonaName,
-            targetUserId,
-            slug,
-            sessionName: personaSessionName,
-            sessionId: effectiveSessionId,
-            messageCount,
-            firstTimestamp: artifactFirstTimestamp,
-            lastTimestamp: artifactLastTimestamp,
-          });
-
-    return {
-      version: "persona-skill-v1",
-      generated_at: new Date().toISOString(),
-      slug,
-      mode: artifactMode || "manual",
-      target: {
-        user_id: targetUserId,
-        name: artifactPersonaName,
-      },
-      source: {
-        tenant_id: config.tenantId,
-        session_id: effectiveSessionId,
-        session_name: personaSessionName,
-        channel: profileChannel,
-        source_key: profileSourceKey || "wxbot",
-        source_label: profileSourceLabel || personaSessionName || "当前群",
-        job_id: jobId ? Number(jobId) : null,
-      },
-      knowledge: {
-        message_count: messageCount,
-        first_timestamp: artifactFirstTimestamp,
-        last_timestamp: artifactLastTimestamp,
-        messages_text: artifactKnowledgeText,
-        knowledge_sources: Array.isArray((meta as { knowledge_sources?: unknown }).knowledge_sources)
-          ? ((meta as { knowledge_sources: unknown[] }).knowledge_sources as string[])
-          : [],
-        source_sessions: Array.isArray((meta as { source_sessions?: unknown }).source_sessions)
-          ? ((meta as { source_sessions: unknown[] }).source_sessions as string[])
-          : [effectiveSessionId].filter(Boolean),
-      },
-      files: {
-        "SKILL.md": skillMd,
-        skill_prompt: skillPrompt,
-        "persona.md": artifactPersonaMd,
-        "work.md": artifactWorkMd,
-      },
-      meta,
-    } satisfies PersonaArtifact;
-  };
-
-  const saveProfile = async () => {
-    const groupId = requireSelectedGroup(config, verifiedGroupIds);
-    if (!profileLoaded) {
-      const error = new Error("当前群风格技能尚未成功读取，请先读取后再保存，避免覆盖线上配置");
-      setProfileOutput(formatJson({ error: error.message }));
-      throw error;
-    }
-    if (!personaDisplayName) {
-      const error = new Error("请填写人格名称或技能标识");
-      setProfileOutput(formatJson({ error: error.message }));
-      throw error;
-    }
-    if (!artifactSkillPrompt.trim()) {
-      const error = new Error("请填写技能提示词正文后再保存");
-      setProfileOutput(formatJson({ error: error.message }));
-      throw error;
-    }
-    const intent = `persona:save:${config.tenantId}:${groupId}:${profileId || "new"}:${profileSkillSlug}:${targetUserId}`;
-    try {
-      const artifact = buildArtifactDraft();
-      const result = await apiRequest<PersonaProfile>(config, "/plugins/persona_extract/profiles", {
-        auth: true,
-        init: {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Idempotency-Key": keyFor(intent),
-          },
-          body: JSON.stringify({
-            profile_id: profileId ? Number(profileId) : null,
-            tenant_id: config.tenantId,
-            session_id: groupId,
-            session_name: personaSessionName,
-            channel: profileChannel,
-            source_key: profileSourceKey || "wxbot",
-            source_label: profileSourceLabel || personaSessionName || "当前群",
-            profile_name: personaDisplayName,
-            target_user_id: targetUserId,
-            target_name: targetName || personaDisplayName,
-            skill_slug: profileSkillSlug,
-            prompt_text: artifactSkillPrompt,
-            artifact,
-            enabled: profileEnabled === "true",
-            job_id: jobId ? Number(jobId) : null,
-          }),
-        },
-      });
-      if (result.id != null) {
-        setProfileId(String(result.id));
-      }
-      await listProfiles();
+      setStylePreview(result);
       setProfileOutput(formatJson(result));
+      await listProfiles({ quiet: true });
       clear(intent);
     } catch (err) {
-      setProfileOutput(formatJson({ error: err instanceof Error ? err.message : "保存风格技能失败" }));
-      throw err;
-    }
-  };
-
-  const applyJobToProfile = async (selectedJobId?: number | string) => {
-    const groupId = requireSelectedGroup(config, verifiedGroupIds);
-    const effectiveJobId = String(selectedJobId || jobId || "").trim();
-    if (!effectiveJobId) {
-      setProfileOutput(formatJson({ error: "请先选择任务 ID" }));
-      return;
-    }
-    const numericJobId = Number(effectiveJobId);
-    if (!Number.isFinite(numericJobId)) {
-      setProfileOutput(formatJson({ error: "任务 ID 必须是数字" }));
-      return;
-    }
-    const jobForApply = jobs.find((item) => String(item.id) === effectiveJobId) || null;
-    if (
-      !jobForApply
-      || jobForApply.session_id !== groupId
-      || jobForApply.status !== "completed"
-    ) {
-      const error = new Error("只能应用当前已验证群内已完成的蒸馏任务");
-      setProfileOutput(formatJson({ error: error.message }));
-      throw error;
-    }
-    const intent = `persona:apply:${config.tenantId}:${groupId}:${numericJobId}:${profileEnabled}`;
-    try {
-      const result = await apiRequest<PersonaProfile>(config, "/plugins/persona_extract/profiles/apply-job", {
-        auth: true,
-        init: {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Idempotency-Key": keyFor(intent),
-          },
-          body: JSON.stringify({
-            tenant_id: config.tenantId,
-            session_id: groupId,
-            session_name: personaSessionName || jobForApply?.session_name || "",
-            job_id: numericJobId,
-            channel: profileChannel,
-            source_key: profileSourceKey || "wxbot",
-            source_label: profileSourceLabel || personaSessionName || "当前群",
-            profile_name: jobForApply?.target_name || profileName || targetName || "default",
-            enabled: profileEnabled === "true",
-          }),
-        },
-      });
-      hydrateProfileForm(result, { syncJobId: false });
-      await listProfiles({ hydrateFirst: false });
-      hydrateProfileForm(result, { syncJobId: false });
-      setProfileOutput(formatJson(result));
-      clear(intent);
-    } catch (err) {
-      setProfileOutput(formatJson({ error: err instanceof Error ? err.message : "应用蒸馏任务失败" }));
+      setProfileOutput(formatJson({ error: err instanceof Error ? err.message : "应用回复风格失败" }));
       throw err;
     }
   };
@@ -936,9 +469,9 @@ export function PersonaWorkspace() {
   const activateProfile = async (profile: PersonaProfile) => {
     const groupId = requireSelectedGroup(config, verifiedGroupIds);
     if (profile.session_id !== groupId) {
-      throw new Error("只能启用当前群的风格技能");
+      throw new Error("只能启用当前群的风格档案");
     }
-    const intent = `persona:activate:${config.tenantId}:${groupId}:${profile.id}`;
+    const intent = `portrait:activate:${config.tenantId}:${groupId}:${profile.id}`;
     try {
       const result = await apiRequest<PersonaProfile>(
         config,
@@ -951,270 +484,61 @@ export function PersonaWorkspace() {
               "Content-Type": "application/json",
               "Idempotency-Key": keyFor(intent),
             },
-            body: JSON.stringify({
-              tenant_id: config.tenantId,
-              session_id: groupId,
-            }),
+            body: JSON.stringify({ tenant_id: config.tenantId, session_id: groupId }),
           },
         },
       );
-      hydrateProfileForm(result, { syncJobId: true });
-      await listProfiles({ hydrateFirst: false });
-      hydrateProfileForm(result, { syncJobId: true });
       setProfileOutput(formatJson(result));
+      await listProfiles({ quiet: true });
       clear(intent);
     } catch (err) {
-      setProfileOutput(formatJson({ error: err instanceof Error ? err.message : "启用风格技能失败" }));
+      setProfileOutput(formatJson({ error: err instanceof Error ? err.message : "启用风格档案失败" }));
       throw err;
     }
   };
 
-  const rerunJob = async (selectedJobId: number | string) => {
+  const deleteProfile = async (profile: PersonaProfile) => {
     const groupId = requireSelectedGroup(config, verifiedGroupIds);
-    const effectiveJobId = String(selectedJobId || "").trim();
-    if (!effectiveJobId) {
-      setOutput(formatJson({ error: "请先选择任务 ID" }));
-      return;
+    if (profile.session_id !== groupId) {
+      throw new Error("只能删除当前群的风格档案");
     }
-    const scopedJob = jobs.find((item) => String(item.id) === effectiveJobId);
-    if (
-      !scopedJob
-      || scopedJob.session_id !== groupId
-      || !members.some((item) => item.wxid === scopedJob.target_user_id)
-    ) {
-      const error = new Error("只能重跑当前已验证群内的任务");
-      setOutput(formatJson({ error: error.message }));
-      throw error;
-    }
-    const intent = `persona:rerun:${config.tenantId}:${groupId}:${effectiveJobId}`;
-    const clientRequestId = keyFor(intent);
-    const previousAttemptCount = Number(scopedJob.attempt_count || 0);
-    setJobNotice("");
+    const deleteQuery = new URLSearchParams({
+      tenant_id: config.tenantId,
+      session_id: groupId,
+    });
     try {
-      const result = await apiRequest<PersonaJobMutationResponse>(config, `/plugins/persona_extract/jobs/${effectiveJobId}/run`, {
-        auth: true,
-        init: {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Idempotency-Key": clientRequestId,
-          },
-          body: "[]",
-        },
-      });
-      if (result.job_id != null) {
-        setJobId(String(result.job_id));
-      }
-      if (result.job) {
-        mergeJobUpdate(result.job, { select: true, preserveDirtyArtifact: true });
-      }
-      if (!result.job) await listJobs({ hydrateFirst: false });
-      setOutput(formatJson(result));
-      setJobNotice(result.accepted === false
-        ? "重跑请求已记录，但执行器暂未接收；请稍后刷新任务状态。"
-        : "任务已重新进入异步队列。",
-      );
-      clear(intent);
-    } catch (err) {
-      const recovered = await reconcileSubmittedJob(clientRequestId, {
-        jobId: effectiveJobId,
-        previousAttemptCount,
-      });
-      if (recovered) {
-        setJobNotice("重跑响应中断，但已核对到任务进入执行流程；无需再次重跑。");
-        setOutput(formatJson({ status: "submission_result_reconciled", job: recovered }));
-        clear(intent);
-        return;
-      }
-      const message = err instanceof Error ? err.message : "重跑任务失败";
-      setJobNotice(`重跑结果未知（请求标识 ${clientRequestId}）。请先刷新任务核对，不要重复操作。`);
-      setOutput(formatJson({
-        status: "submission_result_unknown",
-        client_request_id: clientRequestId,
-        error: message,
-      }));
-      throw new Error("重跑结果未知，系统未核对到任务状态变化；请先刷新任务列表");
-    }
-  };
-
-  const cancelJob = async (selectedJobId: number | string) => {
-    const groupId = requireSelectedGroup(config, verifiedGroupIds);
-    const effectiveJobId = String(selectedJobId || "").trim();
-    const scopedJob = jobs.find((item) => String(item.id) === effectiveJobId);
-    if (!scopedJob || scopedJob.session_id !== groupId || !isActivePersonaJob(scopedJob)) {
-      const error = new Error("只能取消当前已验证群内仍在排队或运行的任务");
-      setOutput(formatJson({ error: error.message }));
-      throw error;
-    }
-    const intent = `persona:cancel:${config.tenantId}:${groupId}:${effectiveJobId}`;
-    const clientRequestId = keyFor(intent);
-    setJobNotice("");
-    try {
-      const result = await apiRequest<PersonaJob | PersonaJobMutationResponse>(
+      const result = await apiRequest(
         config,
-        `/plugins/persona_extract/jobs/${effectiveJobId}/cancel`,
-        {
-          auth: true,
-          init: {
-            method: "POST",
-            headers: { "Idempotency-Key": clientRequestId },
-          },
-        },
+        `/plugins/persona_extract/profiles/${profile.id}?${deleteQuery.toString()}`,
+        { auth: true, init: { method: "DELETE" } },
       );
-      const nestedJob = "job" in result ? result.job : undefined;
-      const directJob = "id" in result ? result : undefined;
-      const updatedJob = nestedJob || directJob || {
-        ...scopedJob,
-        status: result.status || scopedJob.status,
-        cancel_requested: result.cancel_requested ?? true,
-      };
-      mergeJobUpdate(updatedJob, { preserveDirtyArtifact: true });
-      setOutput(formatJson(result));
-      setJobNotice(updatedJob.status === "cancelled"
-        ? `任务 #${effectiveJobId} 已取消。`
-        : `任务 #${effectiveJobId} 已申请取消，执行器会在安全检查点停止。`,
-      );
-      clear(intent);
-    } catch (err) {
-      const items = await listJobs({ hydrateFirst: false, quiet: true });
-      const recovered = items?.find((item) => (
-        String(item.id) === effectiveJobId
-        && (item.status === "cancelled" || item.cancel_requested)
-      ));
-      if (recovered) {
-        mergeJobUpdate(recovered, { preserveDirtyArtifact: true });
-        setJobNotice("取消响应中断，但已核对到取消状态；无需重复操作。");
-        clear(intent);
-        return;
-      }
-      const message = err instanceof Error ? err.message : "取消任务失败";
-      setJobNotice("取消结果未知，请刷新任务确认状态后再操作。");
-      setOutput(formatJson({ status: "cancel_result_unknown", job_id: effectiveJobId, error: message }));
-      throw new Error("取消结果未知，请刷新任务确认状态后再操作");
-    }
-  };
-
-  const deleteProfile = async () => {
-    const groupId = requireSelectedGroup(config, verifiedGroupIds);
-    const scopedProfile = profiles.find((item) => String(item.id) === String(profileId));
-    if (!scopedProfile || scopedProfile.session_id !== groupId) {
-      const error = new Error("请先从当前群的风格技能列表选择目标");
-      setProfileOutput(formatJson({ error: error.message }));
-      throw error;
-    }
-    const intent = `persona:delete:${config.tenantId}:${groupId}:${profileId}`;
-    try {
-      const deleteQuery = new URLSearchParams({
-        tenant_id: config.tenantId,
-        session_id: groupId,
-      });
-      const result = await apiRequest(config, `/plugins/persona_extract/profiles/${profileId}?${deleteQuery.toString()}`, {
-        auth: true,
-        init: {
-          method: "DELETE",
-          headers: { "Idempotency-Key": keyFor(intent) },
-        },
-      });
-      await listProfiles();
       setProfileOutput(formatJson(result));
-      clear(intent);
+      await listProfiles({ quiet: true });
     } catch (err) {
-      setProfileOutput(formatJson({ error: err instanceof Error ? err.message : "删除风格技能失败" }));
+      setProfileOutput(formatJson({ error: err instanceof Error ? err.message : "删除风格档案失败" }));
       throw err;
     }
   };
 
-  const profileDraftFingerprint = useMemo(
-    () => JSON.stringify({
-      profileId,
-      profileName,
-      profileChannel,
-      profileSourceKey,
-      profileSourceLabel,
-      profileEnabled,
-      profileSkillSlug,
-      targetUserId,
-      targetName,
-      jobId,
-      artifactMode,
-      artifactSkillPrompt,
-      artifactSkillMd,
-      artifactPersonaMd,
-      artifactWorkMd,
-      artifactMetaJson,
-      artifactKnowledgeText,
-      artifactFirstTimestamp,
-      artifactLastTimestamp,
-      artifactMessageCount,
-    }),
-    [
-      artifactFirstTimestamp,
-      artifactKnowledgeText,
-      artifactLastTimestamp,
-      artifactMessageCount,
-      artifactMetaJson,
-      artifactMode,
-      artifactPersonaMd,
-      artifactSkillMd,
-      artifactSkillPrompt,
-      artifactWorkMd,
-      jobId,
-      profileChannel,
-      profileEnabled,
-      profileId,
-      profileName,
-      profileSkillSlug,
-      profileSourceKey,
-      profileSourceLabel,
-      targetName,
-      targetUserId,
-    ],
-  );
-  const profileDirty = profileLoaded
-    && Boolean(loadedProfileFingerprint)
-    && profileDraftFingerprint !== loadedProfileFingerprint;
-
-  useEffect(() => {
-    profileDirtyRef.current = profileDirty;
-  }, [profileDirty]);
-
-  useEffect(() => {
-    if (profileBaselineRequest <= profileBaselineCaptured) {
-      return;
-    }
-    setLoadedProfileFingerprint(profileDraftFingerprint);
-    setProfileBaselineCaptured(profileBaselineRequest);
-  }, [profileBaselineCaptured, profileBaselineRequest, profileDraftFingerprint]);
-
-  const artifactSummary = useMemo(
-    () => ({
-      slug: profileSkillSlug || "-",
-      mode: artifactMode || "-",
-      messages: artifactMessageCount || "0",
-      first: artifactFirstTimestamp || "-",
-      last: artifactLastTimestamp || "-",
-    }),
-    [artifactFirstTimestamp, artifactLastTimestamp, artifactMessageCount, artifactMode, profileSkillSlug],
-  );
+  const portraitPayload = portrait?.portrait || null;
+  const claimSections = PORTRAIT_CLAIM_SECTIONS.map(({ key, label }) => ({
+    key,
+    label,
+    claims: Array.isArray(portraitPayload?.[key]) ? (portraitPayload?.[key] as Array<Record<string, unknown>>) : [],
+  })).filter((section) => section.claims.length > 0);
 
   return (
     <div className="page-grid persona-page">
-      <UnsavedChangesGuard when={profileDirty} />
       <section className="panel span-2">
         <PageHeader
           eyebrow="回复风格"
-          title="人物蒸馏 / 回复风格"
-          description="沿用旧版微信机器人的人物蒸馏流程：先选择群成员提炼风格，再围绕 work.md、persona.md、SKILL.md 和 meta.json 管理、应用完整产物，而不是只保存一段模型总结。"
+          title="人物画像 / 回复风格"
+          description="以说话人画像为唯一蒸馏管线：为群成员构建画像，画像编译成回复风格并应用到本群；画像热更新后，已应用的风格会自动同步。"
         />
-        <div className="data-flow-note">
-          <strong>当前链路</strong>
-          <span>有限样本仍可在线分块蒸馏；全量数据会流式导出成私有 ZIP，不再把全部消息塞进后台模型上下文。</span>
-          <span>下载后可让 Codex 或其他基于文件夹的工具按 <code>PROMPT.md</code> 处理，再只上传 <code>output/</code>。首次全量产物会记录游标，后续增量包只包含新增消息和旧产物基线。</span>
-        </div>
         <div className="form-grid">
           <div className="field span-2">
             <span>当前已验证群聊</span>
-            <strong>{selectedSessionIsVerified ? (personaSessionName || effectiveSessionId) : "尚未选择"}</strong>
+            <strong>{selectedSessionIsVerified ? (sessionName || effectiveSessionId) : "尚未选择"}</strong>
             <small>
               {selectedSessionIsVerified
                 ? effectiveSessionId
@@ -1239,22 +563,24 @@ export function PersonaWorkspace() {
           <button className="button button-secondary" onClick={() => void loadSessions()}>
             刷新群列表
           </button>
-          <button className="button button-secondary" onClick={() => void loadMembers()} disabled={!selectedSessionIsVerified}>
+          <button
+            className="button button-secondary"
+            onClick={() => void loadMembers()}
+            disabled={!selectedSessionIsVerified}
+          >
             加载群成员
           </button>
-          <button className="button button-primary" onClick={applySelectedMember} disabled={!selectedMember}>
-            应用到蒸馏目标
+          <button
+            className="button button-secondary"
+            onClick={() => void loadPortrait()}
+            disabled={!selectedMemberWxid}
+          >
+            读取画像
           </button>
-        </div>
-        <div className="persona-subhead">
-          <p className="muted-copy">
-            当前会话：<span className="mono">{effectiveSessionId || "-"}</span>
-          </p>
-          <p className="muted-copy">候选列表来自群成员名册，`可提取` 表示当前消息库中存在该成员可用于蒸馏的文本记录。</p>
         </div>
         <div className="table-scroll member-table-scroll">
           <table>
-            <caption className="sr-only">当前群画像蒸馏成员候选</caption>
+            <caption className="sr-only">当前群画像成员候选</caption>
             <thead>
               <tr>
                 <th scope="col">成员</th>
@@ -1274,11 +600,7 @@ export function PersonaWorkspace() {
                     <button
                       type="button"
                       className="table-cell-action"
-                      onClick={() => {
-                      setSelectedMemberWxid(item.wxid || "");
-                      setTargetUserId(item.wxid || "");
-                      setTargetName(getMemberDisplayName(item));
-                      }}
+                      onClick={() => setSelectedMemberWxid(item.wxid || "")}
                     >
                       {getMemberDisplayName(item)}
                     </button>
@@ -1303,35 +625,31 @@ export function PersonaWorkspace() {
         <section className="panel panel-scroll">
           <div className="panel-header">
             <div>
-              <p className="section-kicker">风格提炼任务</p>
-              <h3>蒸馏任务</h3>
+              <p className="section-kicker">画像蒸馏</p>
+              <h3>画像任务</h3>
             </div>
           </div>
           <div className="form-grid">
             <label className="field">
-              <span>蒸馏目标成员</span>
-              <strong>{targetName || "尚未选择"}</strong>
-              <small className="mono">{targetUserId || "仅可从当前群成员名册选择"}</small>
+              <span>画像目标成员</span>
+              <strong>{selectedMemberName || "尚未选择"}</strong>
+              <small className="mono">{selectedMemberWxid || "仅可从当前群成员名册选择"}</small>
             </label>
             <label className="field">
-              <span>目标来源</span>
-              <strong>{members.some((item) => item.wxid === targetUserId) ? "已验证群成员" : "未验证"}</strong>
-              <small>不会接受手工 user_id。</small>
+              <span>任务模式</span>
+              <select
+                value={jobMode}
+                onChange={(event) => setJobMode(event.target.value === "incremental" ? "incremental" : "full")}
+              >
+                <option value="full">全量画像</option>
+                <option value="incremental">增量热更新</option>
+              </select>
             </label>
-            <div className="field span-2 field-toggle">
-              <span>提取范围</span>
-              <label className="toggle-chip">
-                <input type="checkbox" checked={fullExtract} onChange={(event) => setFullExtract(event.target.checked)} />
-                <strong>全量离线</strong>
-                <em>开启后只准备提示词和全量消息文件，不在后台调用大上下文模型。</em>
-              </label>
-            </div>
             <label className="field">
               <span>回溯天数</span>
               <input
                 type="number"
                 value={daysLimit}
-                disabled={fullExtract}
                 onChange={(event) => setDaysLimit(Number(event.target.value))}
               />
             </label>
@@ -1340,547 +658,245 @@ export function PersonaWorkspace() {
               <input
                 type="number"
                 value={maxMessages}
-                disabled={fullExtract}
                 onChange={(event) => setMaxMessages(Number(event.target.value))}
               />
             </label>
-            <label className="field span-2">
-              <span>当前任务</span>
-              <select value={jobId} onChange={(event) => setJobId(event.target.value)}>
-                <option value="">从当前群任务列表选择</option>
-                {jobs.map((item) => (
-                  <option key={item.id} value={item.id}>{`#${item.id} · ${item.target_name || item.target_user_id || "未命名"} · ${personaJobStatusLabel(item.status)}`}</option>
-                ))}
-              </select>
-            </label>
-            <details className="technical-details span-2">
-              <summary>技术详情：测试消息 JSON</summary>
-              <label className="field">
-                <span>仅用于授权测试数据；留空时从当前群按目标成员采样</span>
-                <textarea
-                  rows={6}
-                  value={messages}
-                  onChange={(event) => setMessages(event.target.value)}
-                  placeholder='[{"sender_name":"Alice","text":"...","timestamp":"2026-04-21 10:00:00"}]'
-                />
-              </label>
-            </details>
-            {selectedAwaitingImportJob ? (
-              <label className="field span-2">
-                <span>上传离线生成结果 ZIP</span>
-                <input
-                  ref={offlineArtifactInputRef}
-                  type="file"
-                  aria-label="上传离线生成结果 ZIP"
-                  accept=".zip,application/zip,application/x-zip-compressed"
-                  onChange={(event) => setOfflineArtifactFile(event.target.files?.[0] || null)}
-                />
-                <small>只能包含 output/SKILL.md、persona.md、work.md、meta.json；不要上传原始消息。</small>
-              </label>
-            ) : null}
           </div>
           <div className="action-row">
+            <button
+              className="button button-primary"
+              onClick={() => void createJob()}
+              disabled={!selectedSessionIsVerified || !selectedMemberWxid}
+            >
+              创建画像任务
+            </button>
             <button className="button button-secondary" onClick={() => void listJobs()}>
               刷新任务
             </button>
-            <button className="button button-secondary" onClick={() => void getJob()} disabled={!jobId}>
-              读取任务
-            </button>
-            <DangerAction
-              label={fullExtract ? "准备全量离线包" : "创建并执行蒸馏"}
-              title={fullExtract ? "确认准备全量离线包" : "确认创建人物蒸馏任务"}
-              confirmLabel={fullExtract ? "确认准备离线包" : "确认创建任务"}
-              pendingLabel="正在创建…"
-              disabled={
-                !selectedSessionIsVerified
-                || !members.some((item) => item.wxid === targetUserId)
-              }
-              impact={(
-                <dl>
-                  <div><dt>目标群</dt><dd><code>{effectiveSessionId || "未选择"}</code></dd></div>
-                  <div><dt>目标成员</dt><dd>{targetName || "未选择"} <code>{targetUserId || ""}</code></dd></div>
-                  <div><dt>样本范围</dt><dd>{fullExtract ? "全量文件导出" : `最近 ${daysLimit} 天，最多 ${maxMessages} 条`}</dd></div>
-                  <div><dt>影响</dt><dd>{fullExtract ? "消息只会进入受限离线包，后台不做大上下文生成。" : "会读取获授权的有限消息样本并在线分块生成风格产物。"}</dd></div>
-                </dl>
-              )}
-              onConfirm={createJob}
-            />
-            <DangerAction
-              label="准备增量更新包"
-              title="确认准备人格增量包"
-              confirmLabel="确认准备增量包"
-              pendingLabel="正在创建…"
-              disabled={
-                !selectedSessionIsVerified
-                || !members.some((item) => item.wxid === targetUserId)
-              }
-              impact={(
-                <dl>
-                  <div><dt>目标人物</dt><dd>{targetName || "未选择"}</dd></div>
-                  <div><dt>前提</dt><dd>该人物已完成并应用过一次新版离线全量产物。</dd></div>
-                  <div><dt>范围</dt><dd>从服务端游标之后提取新增消息，并附带旧产物作为基线。</dd></div>
-                </dl>
-              )}
-              onConfirm={() => createOfflineExport("incremental")}
-            />
-            {selectedAwaitingImportJob ? (
-              <>
-                <button
-                  className="button button-secondary"
-                  onClick={() => void downloadOfflineBundle(selectedAwaitingImportJob)}
-                >
-                  下载当前离线包
-                </button>
-                <DangerAction
-                  label="上传生成结果"
-                  title="确认上传离线人格产物"
-                  confirmLabel="确认上传"
-                  pendingLabel="正在校验…"
-                  disabled={!offlineArtifactFile}
-                  impact={<p>只导入结构化人格产物；上传包中的原始消息或额外文件会被拒绝。</p>}
-                  onConfirm={uploadOfflineArtifact}
-                />
-              </>
-            ) : null}
           </div>
-          {jobNotice ? <p className="muted-copy" role="status">{jobNotice}</p> : null}
-          <div
-            className="table-scroll compact-table-scroll"
-            role="region"
-            aria-label="当前群人物画像蒸馏任务表格"
-            tabIndex={0}
-          >
+          {jobNotice ? <p className="muted-copy">{jobNotice}</p> : null}
+          <div className="table-scroll">
             <table>
-              <caption className="sr-only">当前群人物画像蒸馏任务</caption>
+              <caption className="sr-only">当前群画像蒸馏任务</caption>
               <thead>
                 <tr>
-                  <th scope="col">ID</th>
-                  <th scope="col">人物</th>
-                  <th scope="col">技能标识 / 生成模式</th>
-                  <th scope="col">阶段</th>
-                  <th scope="col">耗时 / 尝试</th>
+                  <th scope="col">#</th>
+                  <th scope="col">成员</th>
+                  <th scope="col">模式</th>
                   <th scope="col">状态</th>
-                  <th scope="col">操作</th>
+                  <th scope="col">消息数</th>
+                  <th scope="col">耗时</th>
+                  <th scope="col">错误</th>
                 </tr>
               </thead>
               <tbody>
                 {jobs.map((item) => (
-                  <tr
-                    key={item.id}
-                    className={String(item.id) === String(jobId || "") ? "table-row-active" : ""}
-                  >
-                    <th scope="row" className="mono">
-                      <button type="button" className="table-cell-action mono" onClick={() => hydrateJobSelection(item)}>
-                        {item.id}
-                      </button>
-                    </th>
-                    <td>{item.target_name || item.target_user_id || "-"}</td>
-                    <td>{item.output_slug || "-"} / {personaArtifactModeLabel(item.mode)}</td>
-                    <td>{personaJobStageLabel(item.current_stage, item.checkpoint)}</td>
-                    <td>
-                      <span>{personaJobDurationLabel(item)}</span>
-                      <div className="muted-copy">{personaJobRetryLabel(item)}</div>
-                    </td>
-                    <td>
-                      <span className={item.status === "failed" ? "pill pill-danger" : item.status === "completed" ? "pill pill-ok" : "pill pill-muted"}>
-                        {item.cancel_requested && isActivePersonaJob(item) ? "取消中" : personaJobStatusLabel(item.status)}
-                      </span>
-                      {item.status === "failed" ? (
-                        <div className="persona-job-error" title={item.error || ""}>
-                          {shortJobError(item)}
-                        </div>
-                      ) : null}
-                    </td>
-                    <td>
-                      <DangerAction
-                        label="应用"
-                        title="确认应用蒸馏结果"
-                        confirmLabel="确认应用"
-                        className="button-compact"
-                        disabled={item.status !== "completed" || item.session_id !== effectiveSessionId}
-                        impact={<p>将任务 #{item.id} 的人物风格应用到当前群；现有同范围配置可能被更新。</p>}
-                        onConfirm={async () => {
-                          hydrateJobSelection(item);
-                          await applyJobToProfile(item.id);
-                        }}
-                      />
-                      {item.status === "failed" ? (
-                        <DangerAction
-                          label="重跑"
-                          title="确认重跑蒸馏任务"
-                          confirmLabel="确认重跑"
-                          className="button-compact"
-                          disabled={item.session_id !== effectiveSessionId}
-                          impact={<p>任务 #{item.id} 将重新读取当前群授权样本并执行，失败记录会保留。</p>}
-                          onConfirm={() => rerunJob(item.id)}
-                        />
-                      ) : null}
-                      {item.status === "awaiting_import" ? (
-                        <button
-                          type="button"
-                          className="button button-secondary button-compact"
-                          onClick={() => {
-                            hydrateJobSelection(item);
-                            void downloadOfflineBundle(item);
-                          }}
-                        >
-                          下载包
-                        </button>
-                      ) : null}
-                      {isActivePersonaJob(item) ? (
-                        <DangerAction
-                          label="取消"
-                          title="确认取消蒸馏任务"
-                          confirmLabel="确认取消"
-                          pendingLabel="正在取消…"
-                          className="button-compact"
-                          disabled={item.session_id !== effectiveSessionId || Boolean(item.cancel_requested)}
-                          impact={<p>任务 #{item.id} 会在安全检查点停止；已经持久化的分段进度会保留。</p>}
-                          onConfirm={() => cancelJob(item.id)}
-                        />
-                      ) : null}
-                    </td>
+                  <tr key={item.id}>
+                    <td className="mono">{item.id}</td>
+                    <td>{item.speaker_name || item.speaker_id || "-"}</td>
+                    <td>{portraitJobModeLabel(item.mode)}</td>
+                    <td>{portraitJobStatusLabel(item.status)}</td>
+                    <td>{item.message_count ?? 0}</td>
+                    <td>{portraitJobDurationLabel(item)}</td>
+                    <td>{shortPortraitJobError(item)}</td>
                   </tr>
                 ))}
                 {!jobs.length && (
                   <tr>
-                    <td colSpan={7}>当前群还没有蒸馏任务</td>
+                    <td colSpan={7}>当前群还没有画像任务</td>
                   </tr>
                 )}
               </tbody>
             </table>
           </div>
+          <OutputPanel title="任务响应" value={jobOutput} />
         </section>
 
         <section className="panel panel-scroll">
           <div className="panel-header">
             <div>
-              <p className="section-kicker">已应用风格技能</p>
-              <h3>当前群启用的风格技能</h3>
+              <p className="section-kicker">运行时注入</p>
+              <h3>已应用回复风格</h3>
             </div>
           </div>
-          <div className="persona-scope-note">
-            <strong>{personaSessionName || "未选择群"}</strong>
-            <span>当前群可以保存多个风格技能；同一消息渠道和来源键只启用一个，其余技能会保留以便随时切换。</span>
-          </div>
-          <div className="form-grid">
-            <label className="field">
-              <span>当前风格技能</span>
-              <select
-                value={profileId}
-                onChange={(event) => {
-                  const next = profiles.find((item) => String(item.id) === event.target.value);
-                  if (next) {
-                    hydrateProfileForm(next, { syncJobId: true });
-                  } else {
-                    setProfileId("");
-                  }
-                }}
-              >
-                <option value="">新建当前群风格技能</option>
-                {profiles.map((item) => (
-                  <option key={item.id} value={item.id}>
-                    {`#${item.id} · ${item.profile_name || item.target_name || "未命名"} · ${item.enabled ? "当前启用" : "已保存"}`}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="field">
-              <span>配置名称</span>
-              <input value={profileName} onChange={(event) => setProfileName(event.target.value)} />
-            </label>
-            <label className="field">
-              <span>消息渠道</span>
-              <select value={profileChannel} onChange={(event) => setProfileChannel(event.target.value)}>
-                <option value="wechat">微信</option>
-                <option value="all">全部渠道</option>
-                <option value="web">网页</option>
-                <option value="whatsapp">WhatsApp</option>
-                <option value="telegram">Telegram</option>
-                <option value="email">电子邮件</option>
-                <option value="sms">短信</option>
-                <option value="voice">语音</option>
-                <option value="custom">自定义</option>
-              </select>
-            </label>
-            <label className="field">
-              <span>来源键</span>
-              <input value={profileSourceKey} onChange={(event) => setProfileSourceKey(event.target.value)} />
-            </label>
-            <label className="field span-2">
-              <span>来源名称</span>
-              <input value={profileSourceLabel} onChange={(event) => setProfileSourceLabel(event.target.value)} />
-            </label>
-            <label className="field">
-              <span>技能标识</span>
-              <input value={profileSkillSlug} onChange={(event) => setProfileSkillSlug(event.target.value)} />
-            </label>
-            <label className="field">
-              <span>是否启用</span>
-              <select value={profileEnabled} onChange={(event) => setProfileEnabled(event.target.value)}>
-                <option value="true">启用</option>
-                <option value="false">停用</option>
-              </select>
-            </label>
-          </div>
-          <div className="action-row">
-            <button className="button button-secondary" onClick={() => void listProfiles()}>
-              读取当前群 Skill
-            </button>
-            <DangerAction
-              label="从任务应用"
-              title="确认应用蒸馏任务"
-              confirmLabel="确认应用"
-              disabled={!canApplySelectedJob}
-              impact={(
-                <dl>
-                  <div><dt>目标群</dt><dd><code>{effectiveSessionId || "未选择"}</code></dd></div>
-                  <div><dt>任务</dt><dd><code>{jobId || "未选择"}</code></dd></div>
-                  <div><dt>影响</dt><dd>将任务产物设为当前群人物风格配置，并保留任务和配置审计链。</dd></div>
-                </dl>
-              )}
-              onConfirm={() => applyJobToProfile()}
-            />
-            <DangerAction
-              label="保存风格技能"
-              title="确认保存人物回复风格技能"
-              confirmLabel="确认保存"
-              pendingLabel="正在保存…"
-              disabled={
-                !selectedSessionIsVerified
-                || !profileLoaded
-                || !hasSaveablePersonaDraft
-              }
-              impact={(
-                <dl>
-                  <div><dt>目标群</dt><dd><code>{effectiveSessionId || "未选择"}</code></dd></div>
-                  <div><dt>运行人格</dt><dd>{personaDisplayName || "未填写"}</dd></div>
-                  <div><dt>状态</dt><dd>{profileEnabled === "true" ? "保存后启用" : "保存但不启用"}</dd></div>
-                  <div><dt>影响</dt><dd>会更新当前群的回复人格；机器人将以该人格自然说话，安全、事实和记忆受众规则仍优先。</dd></div>
-                </dl>
-              )}
-              onConfirm={saveProfile}
-            />
-            <DangerAction
-              label="删除风格技能"
-              title="确认删除人物回复风格技能"
-              confirmLabel="确认删除"
-              pendingLabel="正在删除…"
-              disabled={!selectedSessionIsVerified || !profiles.some((item) => String(item.id) === String(profileId))}
-              impact={(
-                <dl>
-                  <div><dt>配置 ID</dt><dd><code>{profileId || "未选择"}</code></dd></div>
-                  <div><dt>名称</dt><dd>{profileName || "未命名"}</dd></div>
-                  <div><dt>目标人物</dt><dd>{targetName || targetUserId || "未填写"}</dd></div>
-                  <div><dt>技能标识</dt><dd><code>{profileSkillSlug || "未生成"}</code></dd></div>
-                  <div><dt>影响</dt><dd>删除后该配置不再参与回复风格选择；已生成的蒸馏任务记录不会自动删除。</dd></div>
-                </dl>
-              )}
-              onConfirm={deleteProfile}
-            />
-          </div>
-          <div
-            className="table-scroll compact-table-scroll"
-            role="region"
-            aria-label="当前群已应用回复风格表格"
-            tabIndex={0}
-          >
+          <p className="muted-copy">
+            画像编译出的风格档案按群启用，每个群同一渠道最多一个启用中的档案；画像热更新后，后台会自动重编译并同步这些档案。
+          </p>
+          <div className="table-scroll">
             <table>
-              <caption className="sr-only">当前群已应用回复风格</caption>
+              <caption className="sr-only">当前群回复风格档案</caption>
               <thead>
                 <tr>
-                  <th scope="col">ID</th>
                   <th scope="col">名称</th>
-                  <th scope="col">目标人物</th>
-                  <th scope="col">技能标识</th>
-                  <th scope="col">状态</th>
+                  <th scope="col">标识</th>
+                  <th scope="col">启用</th>
+                  <th scope="col">更新时间</th>
                   <th scope="col">操作</th>
                 </tr>
               </thead>
               <tbody>
                 {profiles.map((item) => (
                   <tr key={item.id}>
-                    <th scope="row" className="mono">
-                      <button type="button" className="table-cell-action mono" onClick={() => hydrateProfileForm(item, { syncJobId: true })}>
-                        {item.id}
-                      </button>
-                    </th>
-                    <td>{item.profile_name || "-"}</td>
-                    <td>{item.target_name || item.target_user_id || "-"}</td>
+                    <th scope="row">{item.profile_name || item.target_name || `#${item.id}`}</th>
                     <td className="mono">{item.skill_slug || "-"}</td>
+                    <td>{item.enabled ? "启用中" : "已停用"}</td>
+                    <td>{item.updated_at || "-"}</td>
                     <td>
-                      <span className={item.enabled ? "pill pill-ok" : "pill pill-muted"}>
-                        {item.enabled ? "当前启用" : "已保存"}
-                      </span>
-                    </td>
-                    <td>
-                      {item.enabled ? (
-                        <span className="muted-copy">使用中</span>
-                      ) : (
+                      <div className="action-row action-row-compact">
+                        <button
+                          className="button button-secondary"
+                          onClick={() => void activateProfile(item)}
+                          disabled={Boolean(item.enabled)}
+                        >
+                          启用
+                        </button>
                         <DangerAction
-                          label="启用"
-                          title="确认切换当前群回复风格"
-                          confirmLabel="确认启用"
-                          className="button-compact"
-                          impact={<p>启用“{item.profile_name || item.target_name || item.skill_slug}”，当前同范围风格会保留但停用。</p>}
-                          onConfirm={() => activateProfile(item)}
+                          label="删除"
+                          title={`删除风格档案 ${item.profile_name || item.id}`}
+                          impact="删除后该群将不再注入此回复风格。"
+                          confirmLabel="确认删除"
+                          onConfirm={() => deleteProfile(item)}
                         />
-                      )}
+                      </div>
                     </td>
                   </tr>
                 ))}
                 {!profiles.length && (
                   <tr>
-                    <td colSpan={6}>当前群还没有已应用的回复风格技能</td>
+                    <td colSpan={5}>当前群还没有风格档案；先创建画像再应用。</td>
                   </tr>
                 )}
               </tbody>
             </table>
           </div>
+          <div className="action-row">
+            <button className="button button-secondary" onClick={() => void listProfiles()}>
+              刷新档案
+            </button>
+          </div>
+          <OutputPanel title="档案响应" value={profileOutput} />
         </section>
       </div>
 
-      <section className="panel span-2 panel-scroll">
+      <section className="panel span-2">
         <div className="panel-header">
           <div>
-            <p className="section-kicker">产物</p>
-            <h3>蒸馏产物编辑器</h3>
+            <p className="section-kicker">画像结果</p>
+            <h3>{selectedMemberName ? `${selectedMemberName} 的画像` : "画像"}</h3>
           </div>
         </div>
-        <div className="persona-artifact-summary">
-          <div>
-            <span>技能标识</span>
-            <strong>{artifactSummary.slug}</strong>
-          </div>
-          <div>
-            <span>生成模式</span>
-            <strong>{personaArtifactModeLabel(artifactSummary.mode)}</strong>
-          </div>
-          <div>
-            <span>消息数</span>
-            <strong>{artifactSummary.messages}</strong>
-          </div>
-          <div>
-            <span>时间范围</span>
-            <strong>{`${artifactSummary.first} ~ ${artifactSummary.last}`}</strong>
-          </div>
-        </div>
-        <div className="form-grid">
-          <label className="field span-2">
-            <span>技能提示词正文（运行时注入）</span>
-            <textarea
-              rows={8}
-              value={artifactSkillPrompt}
-              onChange={(event) => {
-                artifactEditorDirtyRef.current = true;
-                setArtifactSkillPrompt(event.target.value);
-              }}
-            />
-          </label>
-          <label className="field span-2">
-            <span>SKILL.md</span>
-            <textarea
-              rows={10}
-              value={artifactSkillMd}
-              onChange={(event) => {
-                artifactEditorDirtyRef.current = true;
-                setArtifactSkillMd(event.target.value);
-              }}
-            />
-          </label>
-          <label className="field span-2">
-            <span>persona.md</span>
-            <textarea
-              rows={10}
-              value={artifactPersonaMd}
-              onChange={(event) => {
-                artifactEditorDirtyRef.current = true;
-                setArtifactPersonaMd(event.target.value);
-              }}
-            />
-          </label>
-          <label className="field span-2">
-            <span>work.md</span>
-            <textarea
-              rows={10}
-              value={artifactWorkMd}
-              onChange={(event) => {
-                artifactEditorDirtyRef.current = true;
-                setArtifactWorkMd(event.target.value);
-              }}
-            />
-          </label>
-          <details className="technical-details span-2">
-            <summary>技术详情：meta.json</summary>
-            <label className="field">
-              <span>结构化元数据 JSON</span>
-              <textarea
-                rows={10}
-                value={artifactMetaJson}
-                onChange={(event) => {
-                  artifactEditorDirtyRef.current = true;
-                  setArtifactMetaJson(event.target.value);
-                }}
-              />
-            </label>
-          </details>
-          <label className="field">
-            <span>知识消息最早时间</span>
-            <input
-              value={artifactFirstTimestamp}
-              onChange={(event) => {
-                artifactEditorDirtyRef.current = true;
-                setArtifactFirstTimestamp(event.target.value);
-              }}
-            />
-          </label>
-          <label className="field">
-            <span>知识消息最晚时间</span>
-            <input
-              value={artifactLastTimestamp}
-              onChange={(event) => {
-                artifactEditorDirtyRef.current = true;
-                setArtifactLastTimestamp(event.target.value);
-              }}
-            />
-          </label>
-          <label className="field">
-            <span>知识消息数量</span>
-            <input
-              value={artifactMessageCount}
-              onChange={(event) => {
-                artifactEditorDirtyRef.current = true;
-                setArtifactMessageCount(event.target.value);
-              }}
-            />
-          </label>
-          <label className="field">
-            <span>产物生成模式</span>
-            <input
-              value={artifactMode}
-              onChange={(event) => {
-                artifactEditorDirtyRef.current = true;
-                setArtifactMode(event.target.value);
-              }}
-            />
-          </label>
-          <label className="field span-2">
-            <span>knowledge/messages.txt</span>
-            <textarea
-              rows={8}
-              value={artifactKnowledgeText}
-              onChange={(event) => {
-                artifactEditorDirtyRef.current = true;
-                setArtifactKnowledgeText(event.target.value);
-              }}
-            />
-          </label>
-        </div>
+        {portrait ? (
+          <>
+            <div className="form-grid">
+              <div className="field">
+                <span>画像概要</span>
+                <strong>{portraitPayload?.summary || "-"}</strong>
+              </div>
+              <div className="field">
+                <span>置信度 / 覆盖</span>
+                <strong>
+                  {portraitConfidenceLabel(portraitPayload)} · {portraitCoverageLabel(portraitPayload)}
+                </strong>
+              </div>
+              <div className="field">
+                <span>最近更新</span>
+                <strong>{portrait.updated_at || "-"}</strong>
+                <small>
+                  热更新{portrait.hot_update_enabled === false ? "已关闭" : "开启"}
+                  {typeof portrait.pending_messages === "number"
+                    ? ` · 待处理新消息 ${portrait.pending_messages} 条`
+                    : ""}
+                </small>
+              </div>
+            </div>
+            <div className="form-grid">
+              {claimSections.map((section) => (
+                <div className="field" key={String(section.key)}>
+                  <span>{section.label}</span>
+                  <ul className="plain-list">
+                    {section.claims.slice(0, 8).map((claim, index) => (
+                      <li key={`${String(section.key)}-${index}`}>
+                        {String((claim as { text?: string }).text || "")}
+                        {Number((claim as { count?: number }).count) > 1
+                          ? `（${Number((claim as { count?: number }).count)} 次）`
+                          : ""}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+              {portraitPayload?.unknowns?.length ? (
+                <div className="field">
+                  <span>未知信息</span>
+                  <ul className="plain-list">
+                    {portraitPayload.unknowns.slice(0, 8).map((item, index) => (
+                      <li key={`unknown-${index}`}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </div>
+          </>
+        ) : (
+          <p className="muted-copy">
+            {selectedMemberWxid
+              ? "该成员还没有画像；创建画像任务完成后这里会显示画像内容。"
+              : "请先从上方名册选择群成员。"}
+          </p>
+        )}
+        <OutputPanel title="画像数据" value={portraitOutput} />
       </section>
 
-      <OutputPanel title="群会话 / 成员响应" value={selectionOutput} />
-      <OutputPanel title="蒸馏任务响应" value={output} />
-      <OutputPanel title="风格技能管理响应" value={profileOutput} />
+      <section className="panel span-2">
+        <div className="panel-header">
+          <div>
+            <p className="section-kicker">画像 → 回复风格</p>
+            <h3>编译并应用回复风格</h3>
+          </div>
+        </div>
+        <p className="muted-copy">
+          风格由画像即时编译（第一人称 COS 提示词），应用后写入本群风格档案并参与群聊回复。
+          {appliedProfile
+            ? ` 当前成员已应用：${appliedProfile.profile_name || appliedProfile.skill_slug}（${appliedProfile.enabled ? "启用中" : "已停用"}）。`
+            : " 当前成员尚未应用回复风格。"}
+        </p>
+        <div className="action-row">
+          <button
+            className="button button-secondary"
+            onClick={() => void previewStyle()}
+            disabled={!selectedMemberWxid || !portrait}
+          >
+            预览风格提示词
+          </button>
+          <label className="toggle-chip">
+            <input
+              type="checkbox"
+              checked={styleEnabled}
+              onChange={(event) => setStyleEnabled(event.target.checked)}
+            />
+            <strong>应用后立即启用</strong>
+          </label>
+          <button
+            className="button button-primary"
+            onClick={() => void applyStyle()}
+            disabled={!selectedSessionIsVerified || !selectedMemberWxid || !portrait}
+          >
+            应用为本群回复风格
+          </button>
+        </div>
+        {stylePreview?.prompt ? (
+          <label className="field span-2">
+            <span>
+              风格提示词（{stylePreview.name || selectedMemberName || "-"} · {stylePreview.prompt_chars ?? stylePreview.prompt.length} 字）
+            </span>
+            <textarea rows={12} value={stylePreview.prompt} readOnly />
+          </label>
+        ) : null}
+      </section>
+
+      <section className="panel span-2">
+        <OutputPanel title="选择过程" value={selectionOutput} />
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/persona/model.ts
+++ b/frontend/src/pages/persona/model.ts
@@ -29,76 +29,6 @@ export type GroupSessionRosterPayload = {
   count?: number;
 };
 
-export type PersonaArtifact = {
-  version?: string;
-  generated_at?: string;
-  slug?: string;
-  mode?: string;
-  target?: {
-    user_id?: string;
-    name?: string;
-  };
-  source?: {
-    tenant_id?: string;
-    session_id?: string;
-    session_name?: string;
-    channel?: string;
-    source_key?: string;
-    source_label?: string;
-    job_id?: number | null;
-  };
-  knowledge?: {
-    message_count?: number;
-    first_timestamp?: string;
-    last_timestamp?: string;
-    messages_text?: string;
-    knowledge_sources?: string[];
-    source_sessions?: string[];
-  };
-  files?: {
-    "SKILL.md"?: string;
-    skill_prompt?: string;
-    "persona.md"?: string;
-    "work.md"?: string;
-  };
-  meta?: Record<string, unknown>;
-};
-
-export type PersonaJob = {
-  id: number;
-  tenant_id?: string;
-  session_id: string;
-  session_name?: string;
-  target_user_id?: string;
-  target_name?: string;
-  status?: string;
-  msg_count?: number;
-  days_limit?: number;
-  max_messages?: number;
-  output_slug?: string;
-  mode?: string;
-  current_stage?: string;
-  checkpoint?: {
-    progress?: {
-      total_chunks?: number;
-      completed_chunks?: number;
-    };
-    [key: string]: unknown;
-  } | null;
-  client_request_id?: string;
-  attempt_count?: number;
-  max_attempts?: number;
-  cancel_requested?: boolean;
-  result_text?: string;
-  artifact?: PersonaArtifact | null;
-  error?: string;
-  created_at?: string | null;
-  started_at?: string | null;
-  updated_at?: string | null;
-  completed_at?: string | null;
-  lease_expires_at?: string | null;
-};
-
 export type PersonaProfile = {
   id: number;
   session_id: string;
@@ -110,10 +40,83 @@ export type PersonaProfile = {
   target_name?: string;
   skill_slug?: string;
   prompt_text?: string;
-  artifact?: PersonaArtifact | null;
   enabled?: boolean;
   job_id?: number | null;
   updated_at?: string | null;
+};
+
+export type PortraitClaim = {
+  text?: string;
+  count?: number;
+  last_seen?: string;
+  examples?: string[];
+};
+
+export type PortraitPayload = {
+  summary?: string;
+  likes?: PortraitClaim[];
+  dislikes?: PortraitClaim[];
+  topics?: PortraitClaim[];
+  routines?: PortraitClaim[];
+  voice?: PortraitClaim[];
+  social?: PortraitClaim[];
+  recent_7d?: PortraitClaim[];
+  recent_30d?: PortraitClaim[];
+  unknowns?: string[];
+  confidence?: number;
+  coverage?: {
+    lines_total?: number;
+    lines_read?: number;
+    complete?: boolean;
+  };
+};
+
+export type PortraitRecord = {
+  id?: number;
+  tenant_id?: string;
+  channel?: string;
+  source_key?: string;
+  speaker_id?: string;
+  display_name?: string;
+  session_id?: string;
+  status?: string;
+  pending_messages?: number;
+  last_message_at?: string;
+  hot_update_enabled?: boolean;
+  message_count?: number;
+  created_at?: string | null;
+  updated_at?: string | null;
+  revision_created_at?: string | null;
+  portrait?: PortraitPayload | null;
+  evidence?: Record<string, unknown> | null;
+};
+
+export type PortraitJob = {
+  id: number;
+  tenant_id?: string;
+  session_id?: string;
+  session_name?: string;
+  speaker_id?: string;
+  speaker_name?: string;
+  status?: string;
+  error?: string;
+  days_limit?: number;
+  max_messages?: number;
+  message_count?: number;
+  mode?: string;
+  since_timestamp?: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+  started_at?: string | null;
+  finished_at?: string | null;
+};
+
+export type PortraitStylePreview = {
+  status?: string;
+  name?: string;
+  prompt?: string;
+  prompt_chars?: number;
+  profile_id?: number;
 };
 
 export function isGroupSession(session: Pick<WxbotSession, "session_id" | "kind">) {
@@ -128,69 +131,33 @@ export function getMemberDisplayName(member: GroupRosterCandidate) {
   return member.name || member.remark || member.alias || member.nick_name || member.wxid;
 }
 
-export function personaJobStatusLabel(status?: string) {
+export function portraitJobStatusLabel(status?: string) {
   const labels: Record<string, string> = {
-    pending: "等待中",
     queued: "已排队",
     running: "运行中",
-    awaiting_import: "等待回传",
     completed: "已完成",
     failed: "失败",
-    cancelled: "已取消",
   };
   return labels[status || ""] || status || "未知";
 }
 
-export function personaJobStageLabel(stage?: string, checkpoint?: PersonaJob["checkpoint"]) {
+export function portraitJobModeLabel(mode?: string) {
   const labels: Record<string, string> = {
-    queued: "已排队",
-    pending: "等待执行",
-    claiming: "领取任务",
-    collect_messages: "收集消息",
-    collecting_messages: "收集消息",
-    streaming_export: "流式导出消息",
-    export_ready: "离线包已就绪",
-    prepare: "准备样本",
-    chunking: "拆分消息",
-    map_chunks: "提取分段特征",
-    map: "提取分段特征",
-    reduce: "合并特征",
-    synthesize: "合成人物风格",
-    synthesis: "合成人物风格",
-    synthesis_complete: "人物风格已合成",
-    work: "提炼工作特征",
-    work_complete: "工作特征已完成",
-    persona: "提炼表达风格",
-    persona_complete: "表达风格已完成",
-    skill: "生成风格技能",
-    persist: "保存蒸馏产物",
-    finalizing: "整理蒸馏产物",
-    retry_wait: "等待重试",
-    cancelled: "已取消",
-    disabled: "插件已停用",
-    done: "已完成",
-    completed: "已完成",
+    full: "全量画像",
+    incremental: "增量热更新",
   };
-  const normalized = stage || "";
-  const chunkMatch = normalized.match(/^(?:summarize|map|extract)_chunk_(\d+)(?:_of_(\d+))?$/);
-  if (chunkMatch) {
-    return `提取分段 ${chunkMatch[1]}${chunkMatch[2] ? `/${chunkMatch[2]}` : ""}`;
-  }
-  const progress = checkpoint?.progress;
-  const completedChunks = Number(progress?.completed_chunks);
-  const totalChunks = Number(progress?.total_chunks);
-  const progressText = Number.isFinite(completedChunks) && Number.isFinite(totalChunks) && totalChunks > 0
-    ? `（${Math.max(0, completedChunks)}/${totalChunks}）`
-    : "";
-  return `${labels[normalized] || normalized || "-"}${progressText}`;
+  return labels[mode || ""] || mode || "-";
 }
 
-export function personaJobDurationLabel(job: PersonaJob, now = Date.now()) {
+export function portraitJobDurationLabel(job: PortraitJob, now = Date.now()) {
   const started = Date.parse(String(job.started_at || job.created_at || ""));
-  const terminal = ["completed", "failed", "cancelled"].includes(String(job.status || ""));
-  const ended = Date.parse(String(job.completed_at || (terminal ? job.updated_at : "") || ""));
+  const terminal = ["completed", "failed"].includes(String(job.status || ""));
+  const ended = Date.parse(String(job.finished_at || (terminal ? job.updated_at : "") || ""));
   if (!Number.isFinite(started)) return "-";
-  const durationSeconds = Math.max(0, Math.floor(((Number.isFinite(ended) ? ended : now) - started) / 1000));
+  const durationSeconds = Math.max(
+    0,
+    Math.floor(((Number.isFinite(ended) ? ended : now) - started) / 1000),
+  );
   if (durationSeconds < 60) return `${durationSeconds} 秒`;
   const minutes = Math.floor(durationSeconds / 60);
   const seconds = durationSeconds % 60;
@@ -200,104 +167,35 @@ export function personaJobDurationLabel(job: PersonaJob, now = Date.now()) {
   return remainingMinutes ? `${hours} 小时 ${remainingMinutes} 分` : `${hours} 小时`;
 }
 
-export function personaJobRetryLabel(job: PersonaJob) {
-  const attempts = Math.max(0, Number(job.attempt_count) || 0);
-  const maxAttempts = Math.max(0, Number(job.max_attempts) || 0);
-  if (!attempts) return "尚未尝试";
-  const retries = Math.max(0, attempts - 1);
-  const attemptText = maxAttempts ? `第 ${attempts}/${maxAttempts} 次` : `第 ${attempts} 次`;
-  return retries ? `${attemptText}（已重试 ${retries} 次）` : `${attemptText}（未重试）`;
-}
-
-export function personaArtifactModeLabel(mode?: string) {
-  const labels: Record<string, string> = {
-    manual: "手工编辑",
-    incremental: "增量更新",
-    rebuild: "全量重建",
-    full: "全量生成",
-    offline_full: "离线全量",
-    offline_incremental: "离线增量",
-  };
-  return labels[mode || ""] || mode || "-";
-}
-
-export function buildSkillFrontmatter(slug: string, targetName: string, body: string) {
-  const cleanBody = body.trim();
-  const safeSlug = slug || "default";
-  const safeName = targetName || safeSlug;
-  return [
-    "---",
-    `name: colleague-${safeSlug}`,
-    `description: "${safeName} — 基于聊天记录蒸馏"`,
-    "user-invocable: true",
-    "---",
-    "",
-    cleanBody,
-  ].join("\n");
-}
-
-export function stripFrontmatter(text: string) {
-  const lines = text.replace(/^\uFEFF/, "").split("\n");
-  if (!lines.length || lines[0].trim() !== "---") {
-    return text.trim();
-  }
-  for (let index = 1; index < lines.length; index += 1) {
-    if (lines[index].trim() === "---") {
-      return lines.slice(index + 1).join("\n").trim();
-    }
-  }
-  return text.trim();
-}
-
-export function buildDefaultMeta({
-  targetName,
-  targetUserId,
-  slug,
-  sessionName,
-  sessionId,
-  messageCount,
-  firstTimestamp,
-  lastTimestamp,
-}: {
-  targetName: string;
-  targetUserId: string;
-  slug: string;
-  sessionName: string;
-  sessionId: string;
-  messageCount: number;
-  firstTimestamp: string;
-  lastTimestamp: string;
-}) {
-  const dateMin = firstTimestamp ? firstTimestamp.slice(0, 10) : "?";
-  const dateMax = lastTimestamp ? lastTimestamp.slice(0, 10) : "?";
-  return {
-    name: targetName,
-    slug,
-    wxid: targetUserId,
-    version: "v1",
-    profile: {},
-    tags: { personality: [], culture: [] },
-    impression: "",
-    knowledge_sources: [`${sessionName || sessionId} — ${messageCount} 条 (${dateMin} ~ ${dateMax})`],
-    message_count: messageCount,
-    source_sessions: sessionId ? [sessionId] : [],
-    corrections_count: 0,
-  };
-}
-
-export function getArtifactPrompt(artifact: PersonaArtifact | null | undefined, fallbackPrompt = "") {
-  return (
-    artifact?.files?.skill_prompt ||
-    stripFrontmatter(artifact?.files?.["SKILL.md"] || "") ||
-    fallbackPrompt ||
-    ""
-  );
-}
-
-export function shortJobError(job: PersonaJob) {
-  const stage = (job.current_stage || "").trim();
+export function shortPortraitJobError(job: PortraitJob) {
   const error = (job.error || "").replace(/\s+/g, " ").trim();
-  const shortError = error.length > 120 ? `${error.slice(0, 117)}...` : error;
-  if (stage && shortError) return `${stage}: ${shortError}`;
-  return shortError || stage || "-";
+  if (!error) return "-";
+  return error.length > 120 ? `${error.slice(0, 117)}...` : error;
 }
+
+export function portraitConfidenceLabel(portrait?: PortraitPayload | null) {
+  const confidence = Number(portrait?.confidence);
+  if (!Number.isFinite(confidence)) return "-";
+  return `${Math.round(confidence * 100)}%`;
+}
+
+export function portraitCoverageLabel(portrait?: PortraitPayload | null) {
+  const coverage = portrait?.coverage;
+  if (!coverage) return "-";
+  const total = Number(coverage.lines_total);
+  const read = Number(coverage.lines_read);
+  if (!Number.isFinite(total) || total <= 0) return coverage.complete ? "完整" : "-";
+  const readText = Number.isFinite(read) ? read : "?";
+  return `${readText}/${total}${coverage.complete ? "（完整）" : "（部分）"}`;
+}
+
+export const PORTRAIT_CLAIM_SECTIONS: Array<{ key: keyof PortraitPayload; label: string }> = [
+  { key: "voice", label: "怎么说话" },
+  { key: "social", label: "怎么接话" },
+  { key: "likes", label: "喜欢" },
+  { key: "dislikes", label: "反感" },
+  { key: "topics", label: "常聊话题" },
+  { key: "routines", label: "日常节奏" },
+  { key: "recent_7d", label: "最近 7 天" },
+  { key: "recent_30d", label: "最近 30 天" },
+];

--- a/frontend/src/pages/persona/model.ts
+++ b/frontend/src/pages/persona/model.ts
@@ -173,13 +173,64 @@ export function shortPortraitJobError(job: PortraitJob) {
   return error.length > 120 ? `${error.slice(0, 117)}...` : error;
 }
 
-export function portraitConfidenceLabel(portrait?: PortraitPayload | null) {
-  const confidence = Number(portrait?.confidence);
-  if (!Number.isFinite(confidence)) return "-";
-  return `${Math.round(confidence * 100)}%`;
+export type PortraitFreshness = {
+  distilledRead: number;
+  distilledTotal: number;
+  liveTotal: number;
+  pendingCount: number;
+  sourceCount: number;
+  behind: boolean;
+  complete: boolean;
+};
+
+export function portraitFreshness(
+  portrait?: PortraitRecord | null,
+  sourceMessageCount?: number | null,
+): PortraitFreshness {
+  const coverage = portrait?.portrait?.coverage;
+  const storedTotal = Number(coverage?.lines_total);
+  const storedRead = Number(coverage?.lines_read);
+  const pending = Number(portrait?.pending_messages);
+  const source = Number(sourceMessageCount);
+  const distilledTotal = Number.isFinite(storedTotal) && storedTotal > 0 ? storedTotal : 0;
+  const distilledRead = Number.isFinite(storedRead) && storedRead >= 0 ? storedRead : distilledTotal;
+  const pendingCount = Number.isFinite(pending) && pending > 0 ? Math.floor(pending) : 0;
+  const sourceCount = Number.isFinite(source) && source > 0 ? Math.floor(source) : 0;
+  const liveTotal = Math.max(distilledTotal, distilledRead + pendingCount, sourceCount);
+  const behind = liveTotal > distilledRead || pendingCount > 0;
+  const complete = Boolean(coverage?.complete) && liveTotal > 0 && distilledRead >= liveTotal && pendingCount === 0;
+  return {
+    distilledRead,
+    distilledTotal,
+    liveTotal,
+    pendingCount,
+    sourceCount,
+    behind,
+    complete,
+  };
 }
 
-export function portraitCoverageLabel(portrait?: PortraitPayload | null) {
+export function portraitConfidenceLabel(
+  portrait?: PortraitPayload | null,
+  freshness?: PortraitFreshness | null,
+) {
+  const confidence = Number(portrait?.confidence);
+  if (!Number.isFinite(confidence)) return "-";
+  let score = confidence;
+  if (freshness?.behind && freshness.liveTotal > 0) {
+    score = confidence * Math.min(1, freshness.distilledRead / freshness.liveTotal);
+  }
+  return `${Math.round(score * 100)}%`;
+}
+
+export function portraitCoverageLabel(
+  portrait?: PortraitPayload | null,
+  freshness?: PortraitFreshness | null,
+) {
+  if (freshness && freshness.liveTotal > 0) {
+    const readText = Number.isFinite(freshness.distilledRead) ? freshness.distilledRead : "?";
+    return `${readText}/${freshness.liveTotal}${freshness.complete ? "（完整）" : "（部分）"}`;
+  }
   const coverage = portrait?.coverage;
   if (!coverage) return "-";
   const total = Number(coverage.lines_total);
@@ -187,6 +238,15 @@ export function portraitCoverageLabel(portrait?: PortraitPayload | null) {
   if (!Number.isFinite(total) || total <= 0) return coverage.complete ? "完整" : "-";
   const readText = Number.isFinite(read) ? read : "?";
   return `${readText}/${total}${coverage.complete ? "（完整）" : "（部分）"}`;
+}
+
+export function portraitFreshnessHint(freshness: PortraitFreshness) {
+  const parts: string[] = [];
+  if (freshness.sourceCount) parts.push(`名册 ${freshness.sourceCount} 条`);
+  if (freshness.distilledRead) parts.push(`已蒸馏 ${freshness.distilledRead} 条`);
+  if (freshness.pendingCount) parts.push(`待处理 ${freshness.pendingCount} 条`);
+  if (freshness.behind) parts.push("画像尚未跟上最新聊天记录");
+  return parts.join(" · ");
 }
 
 export const PORTRAIT_CLAIM_SECTIONS: Array<{ key: keyof PortraitPayload; label: string }> = [

--- a/frontend/src/pages/plugins/FlowRuntimeSection.tsx
+++ b/frontend/src/pages/plugins/FlowRuntimeSection.tsx
@@ -663,19 +663,16 @@ export function FlowRuntimeSection({
             <p className="section-kicker">消息流运行状态</p>
             <h3>Flow / Effect 运行视图</h3>
           </div>
-          <div className="action-row">
-            <button
-              className="button button-secondary"
-              type="button"
-              onClick={(event) => {
-                event.preventDefault();
-                void loadFlowRuntimeStatus();
-              }}
-            >
-              {flowLoading ? "刷新中..." : "刷新 Runtime"}
-            </button>
-          </div>
         </summary>
+        <div className="action-row">
+          <button
+            className="button button-secondary"
+            type="button"
+            onClick={() => void loadFlowRuntimeStatus()}
+          >
+            {flowLoading ? "刷新中..." : "刷新 Runtime"}
+          </button>
+        </div>
         {flowError && <p className="muted-copy">{flowError}</p>}
         <div className="flow-runtime-board">
           <div className="flow-runtime-command-center">

--- a/frontend/src/pages/plugins/FlowRuntimeSection.tsx
+++ b/frontend/src/pages/plugins/FlowRuntimeSection.tsx
@@ -657,17 +657,25 @@ export function FlowRuntimeSection({
   return (
     <>
       <section className="panel panel-scroll plugins-flow-panel span-3">
-        <div className="panel-header">
+        <details className="plugins-flow-details">
+        <summary className="panel-header">
           <div>
             <p className="section-kicker">消息流运行状态</p>
             <h3>Flow / Effect 运行视图</h3>
           </div>
           <div className="action-row">
-            <button className="button button-secondary" onClick={() => void loadFlowRuntimeStatus()}>
+            <button
+              className="button button-secondary"
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                void loadFlowRuntimeStatus();
+              }}
+            >
               {flowLoading ? "刷新中..." : "刷新 Runtime"}
             </button>
           </div>
-        </div>
+        </summary>
         {flowError && <p className="muted-copy">{flowError}</p>}
         <div className="flow-runtime-board">
           <div className="flow-runtime-command-center">
@@ -738,7 +746,7 @@ export function FlowRuntimeSection({
           </div>
 
           <div className="flow-runtime-results">
-            <article className={`plugin-card flow-run-card ${runtimeResult?.error ? "has-error" : ""}`}>
+            <article className={`flow-run-card ${runtimeResult?.error ? "has-error" : ""}`}>
               <div className="plugin-card-header">
                 <div>
                   <strong>最近 Runtime</strong>
@@ -763,7 +771,7 @@ export function FlowRuntimeSection({
               {renderFlowTraceTables(runtimeResult)}
             </article>
 
-            <article className={`plugin-card flow-run-card ${shadowResult?.error ? "has-error" : ""}`}>
+            <article className={`flow-run-card ${shadowResult?.error ? "has-error" : ""}`}>
               <div className="plugin-card-header">
                 <div>
                   <strong>最近 Shadow</strong>
@@ -1205,6 +1213,7 @@ export function FlowRuntimeSection({
           </details>
 
         </div>
+        </details>
       </section>
 
       {traceFlowModalOpen && activeTraceAggregate && (

--- a/frontend/src/pages/plugins/GroupPluginScopeSection.tsx
+++ b/frontend/src/pages/plugins/GroupPluginScopeSection.tsx
@@ -87,7 +87,7 @@ export function GroupPluginScopeSection({
                   <strong>{plugin.name}</strong>
                   <span>{label}</span>
                 </div>
-                <span className={`plugin-badge ${enabled ? "" : "is-muted"}`}>{enabled ? "on" : "off"}</span>
+                <span className={`plugin-badge ${enabled ? "" : "is-muted"}`}>{enabled ? "已开启" : "已关闭"}</span>
               </div>
               <p className="muted-copy">{summary}</p>
               {plugin.name === "tibo_reset" && tiboStats && (

--- a/frontend/src/pages/plugins/InstalledPluginsSection.tsx
+++ b/frontend/src/pages/plugins/InstalledPluginsSection.tsx
@@ -1,12 +1,26 @@
 import { Link } from "react-router-dom";
 
+import { Alert } from "../../components/Alert";
 import { DangerAction } from "../../components/DangerAction";
 import type { InstalledPlugin, PluginRuntime } from "./models";
-import { PLUGIN_LINKS } from "./models";
+import { PLUGIN_LINKS, pluginEnablementLabel, pluginRuntimeFacts } from "./models";
+
+const HARDCODED_RUNTIME = new Set([
+  "amap",
+  "commands",
+  "credits",
+  "moderation",
+  "memory",
+  "persona_extract",
+  "wxbot",
+  "repeater",
+]);
 
 type InstalledPluginsSectionProps = {
   pluginCards: InstalledPlugin[];
   runtime: PluginRuntime;
+  selectedPluginName?: string;
+  restartRequired?: boolean;
   canManage: boolean;
   onSetPluginEnabled: (pluginName: string, enabled: boolean) => Promise<void>;
 };
@@ -14,10 +28,13 @@ type InstalledPluginsSectionProps = {
 export function InstalledPluginsSection({
   pluginCards,
   runtime,
+  selectedPluginName = "",
+  restartRequired = false,
   canManage,
   onSetPluginEnabled,
 }: InstalledPluginsSectionProps) {
   const setPluginEnabled = onSetPluginEnabled;
+  const pendingRestart = restartRequired || pluginCards.some((plugin) => plugin.restart_required);
   return (
       <section className="panel panel-scroll plugins-loaded-panel span-3">
         <div className="panel-header">
@@ -26,11 +43,17 @@ export function InstalledPluginsSection({
             <h3>已加载插件</h3>
           </div>
         </div>
+        {pendingRestart && (
+          <Alert variant="warning" title="待重启">
+            带路由或流程步骤的插件改动需要重启服务后才会完全卸下旧入口。禁用后的请求现在会被拒绝，不会被当成已经热卸载。
+          </Alert>
+        )}
         <div className="plugin-card-grid">
           {pluginCards.map((plugin) => (
             <article
               key={plugin.name}
-              className={`plugin-card plugin-plugin-card ${plugin.enabled ? "is-enabled" : "is-disabled"} ${plugin.restart_required ? "is-restart-required" : ""} ${plugin.last_error ? "has-error" : ""}`}
+              id={`plugin-card-${plugin.name}`}
+              className={`plugin-card plugin-plugin-card ${plugin.enabled ? "is-enabled" : "is-disabled"} ${plugin.restart_required ? "is-restart-required" : ""} ${plugin.last_error ? "has-error" : ""} ${selectedPluginName === plugin.name ? "is-selected" : ""}`}
             >
               <div className="plugin-card-header">
                 <div>
@@ -38,13 +61,7 @@ export function InstalledPluginsSection({
                   <span>v{plugin.version}</span>
                 </div>
                 <span className={`plugin-badge ${plugin.restart_required ? "is-warning" : plugin.last_error ? "is-danger" : plugin.enabled ? "" : "is-muted"}`}>
-                  {plugin.restart_required
-                    ? "待重启"
-                    : plugin.last_error
-                      ? "异常"
-                      : plugin.enabled
-                        ? "已启用"
-                        : "已停用"}
+                  {plugin.last_error ? "异常" : pluginEnablementLabel(plugin, runtime)}
                 </span>
               </div>
               <p className="plugin-card-copy">{plugin.description || "无描述"}</p>
@@ -123,6 +140,14 @@ export function InstalledPluginsSection({
                 <dl className="plugin-meta-list">
                   <div><dt>启用</dt><dd>{runtime.repeater?.enabled ? "是" : "否"}</dd></div>
                   <div><dt>冷却时间</dt><dd>{runtime.repeater?.cooldown_seconds ?? 300} 秒</dd></div>
+                </dl>
+              )}
+
+              {!HARDCODED_RUNTIME.has(plugin.name) && pluginRuntimeFacts(plugin.name, runtime).length > 0 && (
+                <dl className="plugin-meta-list">
+                  {pluginRuntimeFacts(plugin.name, runtime).map((fact) => (
+                    <div key={fact.label}><dt>{fact.label}</dt><dd>{fact.value}</dd></div>
+                  ))}
                 </dl>
               )}
 

--- a/frontend/src/pages/plugins/PluginDiagnosticsSections.tsx
+++ b/frontend/src/pages/plugins/PluginDiagnosticsSections.tsx
@@ -92,10 +92,10 @@ export function PluginDiagnosticsSections({
       </section>
 
       <div className="plugins-output-panel span-3">
-        <OutputPanel title="插件摘要响应" value={output} />
+        <OutputPanel flush title="插件摘要响应" value={output} />
       </div>
       <div className="plugins-output-panel span-3">
-        <OutputPanel title="群级插件控制响应" value={groupOutput} />
+        <OutputPanel flush title="群级插件控制响应" value={groupOutput} />
       </div>
     </>
   );

--- a/frontend/src/pages/plugins/PluginOverviewSection.tsx
+++ b/frontend/src/pages/plugins/PluginOverviewSection.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 import { PageHeader } from "../../components/PageHeader";
 import { StatusTile } from "../../components/StatusTile";
 import type { InstalledPlugin, PluginRuntime, PluginSummary } from "./models";
@@ -63,10 +65,10 @@ export function PluginOverviewSection({
             const status = pluginStatus(name);
             return (
               <li key={name} data-enabled={status === "已启用" ? "true" : "false"}>
-                <a href={`/plugins?plugin=${encodeURIComponent(name)}`}>
+                <Link to={`/plugins?plugin=${encodeURIComponent(name)}`}>
                   <span>{label}</span>
                   <strong>{status}</strong>
-                </a>
+                </Link>
               </li>
             );
           })}

--- a/frontend/src/pages/plugins/PluginOverviewSection.tsx
+++ b/frontend/src/pages/plugins/PluginOverviewSection.tsx
@@ -1,25 +1,43 @@
 import { PageHeader } from "../../components/PageHeader";
 import { StatusTile } from "../../components/StatusTile";
-import type { InstalledPlugin, PluginSummary } from "./models";
+import type { InstalledPlugin, PluginRuntime, PluginSummary } from "./models";
+import { pluginEnablementLabel } from "./models";
 
 type PluginOverviewSectionProps = {
   data: PluginSummary | null;
   pluginCards: InstalledPlugin[];
+  runtime: PluginRuntime;
   loading: boolean;
   canRefresh: boolean;
   onRefresh: () => void;
 };
 
+const OVERVIEW_PLUGINS: Array<[string, string]> = [
+  ["命令中心", "commands"],
+  ["高德地图", "amap"],
+  ["积分运营", "credits"],
+  ["成员记忆", "memory"],
+  ["内容审核", "moderation"],
+  ["微信适配器", "wxbot"],
+  ["回复风格", "persona_extract"],
+  ["复读策略", "repeater"],
+  ["Tibo 重置", "tibo_reset"],
+];
+
 export function PluginOverviewSection({
   data,
   pluginCards,
+  runtime,
   loading,
   canRefresh,
   onRefresh,
 }: PluginOverviewSectionProps) {
   const loadSummary = onRefresh;
   const pluginStatus = (name: string) => (
-    pluginCards.some((item) => item.name === name) ? "已启用" : "未加载"
+    pluginEnablementLabel(
+      pluginCards.find((item) => item.name === name),
+      runtime,
+    )
   );
 
   return (
@@ -28,27 +46,31 @@ export function PluginOverviewSection({
           eyebrow="插件管理"
           title="插件管理总览"
           description="核对插件挂载、Hook 注入与消息平台适配器声明。适配器已加载不代表已经建立平台连接。"
+          actions={
+            <button className="button button-primary" onClick={() => void loadSummary()} disabled={!canRefresh || loading}>
+              {loading ? "刷新中..." : "刷新插件摘要"}
+            </button>
+          }
         />
-        <div className="action-row">
-          <button className="button button-primary" onClick={() => void loadSummary()} disabled={!canRefresh || loading}>
-            {loading ? "刷新中..." : "刷新插件摘要"}
-          </button>
-        </div>
         <div className="status-grid plugins-overview-grid">
           <StatusTile label="插件" value={`${pluginCards.length}`} />
           <StatusTile label="路由" value={`${(data?.plugin_routes ?? []).length}`} />
           <StatusTile label="钩子" value={`${Object.keys(data?.hooks || {}).length}`} />
           <StatusTile label="适配器声明" value={`${(data?.channels ?? []).length}`} />
-          <StatusTile label="命令中心" value={pluginStatus("commands")} />
-          <StatusTile label="高德地图" value={pluginStatus("amap")} />
-          <StatusTile label="积分运营" value={pluginStatus("credits")} />
-          <StatusTile label="成员记忆" value={pluginStatus("memory")} />
-          <StatusTile label="内容审核" value={pluginStatus("moderation")} />
-          <StatusTile label="微信适配器" value={pluginStatus("wxbot")} />
-          <StatusTile label="回复风格" value={pluginStatus("persona_extract")} />
-          <StatusTile label="复读策略" value={pluginStatus("repeater")} />
-          <StatusTile label="Tibo 重置" value={pluginStatus("tibo_reset")} />
         </div>
+        <ul className="plugin-enablement-list" aria-label="插件启用状态">
+          {OVERVIEW_PLUGINS.map(([label, name]) => {
+            const status = pluginStatus(name);
+            return (
+              <li key={name} data-enabled={status === "已启用" ? "true" : "false"}>
+                <a href={`/plugins?plugin=${encodeURIComponent(name)}`}>
+                  <span>{label}</span>
+                  <strong>{status}</strong>
+                </a>
+              </li>
+            );
+          })}
+        </ul>
       </section>
   );
 }

--- a/frontend/src/pages/plugins/PluginsPage.test.tsx
+++ b/frontend/src/pages/plugins/PluginsPage.test.tsx
@@ -8,7 +8,8 @@ import { ConsoleConfigProvider, useConsoleConfig } from "../../state/console-con
 import { PluginDiagnosticsSections } from "./PluginDiagnosticsSections";
 import { PluginOverviewSection } from "./PluginOverviewSection";
 import { FlowRuntimeSection } from "./FlowRuntimeSection";
-import type { PluginSummary } from "./models";
+import type { InstalledPlugin, PluginSummary } from "./models";
+import { pluginEnablementLabel } from "./models";
 
 function AuthenticatedPluginsPage() {
   const { updateConfig } = useConsoleConfig();
@@ -40,7 +41,7 @@ describe("PluginsPage composition", () => {
     const incompleteSummary = { plugins: [] } as unknown as PluginSummary;
 
     render(
-      <>
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <PluginOverviewSection
           data={incompleteSummary}
           pluginCards={[]}
@@ -55,7 +56,7 @@ describe("PluginsPage composition", () => {
           output="{}"
           groupOutput="{}"
         />
-      </>,
+      </MemoryRouter>,
     );
 
     const overview = screen.getByRole("heading", { name: "插件管理总览" }).closest("section");
@@ -324,5 +325,47 @@ describe("PluginsPage composition", () => {
     expect(within(card as HTMLElement).getAllByText("已停用").length).toBeGreaterThan(0);
     expect(within(card as HTMLElement).getByText("接口地址")).toBeInTheDocument();
     expect(within(card as HTMLElement).getAllByText("未配置").length).toBeGreaterThan(0);
+  });
+});
+
+describe("pluginEnablementLabel", () => {
+  const enabledPlugin = (name: string): InstalledPlugin => ({
+    name,
+    version: "1",
+    enabled: true,
+    system: false,
+    status: "active",
+    restart_required: false,
+  });
+
+  it("reports unconfigured for any plugin whose runtime says so", () => {
+    expect(
+      pluginEnablementLabel(enabledPlugin("tibo_reset"), {
+        tibo_reset: { api_url_configured: false },
+      }),
+    ).toBe("未配置");
+    expect(
+      pluginEnablementLabel(enabledPlugin("draw"), {
+        draw: { configured: false, fallback_configured: false },
+      } as never),
+    ).toBe("未配置");
+    expect(
+      pluginEnablementLabel(enabledPlugin("amap"), {
+        amap: { api_key_configured: false },
+      } as never),
+    ).toBe("未配置");
+  });
+
+  it("treats a working fallback endpoint as configured", () => {
+    expect(
+      pluginEnablementLabel(enabledPlugin("draw"), {
+        draw: { configured: false, fallback_configured: true },
+      } as never),
+    ).toBe("已启用");
+  });
+
+  it("keeps enabled label when runtime facts are absent", () => {
+    expect(pluginEnablementLabel(enabledPlugin("draw"), {})).toBe("已启用");
+    expect(pluginEnablementLabel(enabledPlugin("draw"))).toBe("已启用");
   });
 });

--- a/frontend/src/pages/plugins/PluginsPage.test.tsx
+++ b/frontend/src/pages/plugins/PluginsPage.test.tsx
@@ -44,6 +44,7 @@ describe("PluginsPage composition", () => {
         <PluginOverviewSection
           data={incompleteSummary}
           pluginCards={[]}
+          runtime={{}}
           loading={false}
           canRefresh
           onRefresh={() => undefined}
@@ -257,5 +258,71 @@ describe("PluginsPage composition", () => {
     );
     const lifecycleHeaders = new Headers(lifecycleWrite?.[1]?.headers);
     expect(lifecycleHeaders.get("Idempotency-Key")).toMatch(/^agent-console:/);
+  });
+
+  it("opens the installed plugin card named in the query string", async () => {
+    vi.mocked(fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      let body: Record<string, unknown> = {};
+      if (url.includes("/v1/admin/plugins/summary")) {
+        body = {
+          plugins: [{ name: "tibo_reset", version: "1", description: "tibo" }],
+          plugin_routes: [],
+          hooks: {},
+          channels: [],
+          channel_labels: {},
+        };
+      } else if (url.includes("/v1/admin/plugins/installed")) {
+        body = {
+          plugins: [
+            {
+              name: "tibo_reset",
+              version: "1",
+              enabled: false,
+              system: false,
+              status: "disabled",
+              restart_required: false,
+              description: "Tibo Reset",
+            },
+          ],
+        };
+      } else if (url.includes("/v1/admin/plugins/tibo_reset/runtime")) {
+        body = {
+          plugin_name: "tibo_reset",
+          runtime_status: { configured_enabled: false, api_url_configured: false },
+        };
+      } else if (url.includes("/v1/admin/plugins/events")) {
+        body = { events: [] };
+      } else if (url.includes("/v1/admin/message-flows/effects/summary")) {
+        body = { enabled: true, backend: "test", summary: {} };
+      } else if (url.includes("/v1/admin/message-flows/effects")) {
+        body = { enabled: true, backend: "test", items: [] };
+      } else if (url.includes("/readyz")) {
+        body = { status: "ready", checks: {} };
+      }
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    render(
+      <MemoryRouter
+        initialEntries={["/plugins?plugin=tibo_reset"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <ConsoleConfigProvider>
+          <AuthenticatedPluginsPage />
+        </ConsoleConfigProvider>
+      </MemoryRouter>,
+    );
+
+    const name = await screen.findByText("tibo_reset");
+    const card = name.closest("article");
+    expect(card).not.toBeNull();
+    expect(card).toHaveClass("is-selected");
+    expect(within(card as HTMLElement).getAllByText("已停用").length).toBeGreaterThan(0);
+    expect(within(card as HTMLElement).getByText("接口地址")).toBeInTheDocument();
+    expect(within(card as HTMLElement).getAllByText("未配置").length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/pages/plugins/models.ts
+++ b/frontend/src/pages/plugins/models.ts
@@ -501,7 +501,9 @@ export const PLUGIN_DISPLAY_NAMES: Record<string, string> = {
 
 const PLUGIN_RUNTIME_FIELD_LABELS: Record<string, string> = {
   api_url_configured: "接口地址",
-  configured_enabled: "密钥已配置",
+  api_key_configured: "API 密钥",
+  configured: "接口配置",
+  fallback_configured: "备用接口",
   scheduler_enabled: "调度器",
   running: "运行中",
   poll_interval_seconds: "轮询间隔（秒）",
@@ -511,7 +513,24 @@ const PLUGIN_RUNTIME_FIELD_LABELS: Record<string, string> = {
   enabled_groups: "已开群数",
 };
 
-const HIDDEN_RUNTIME_KEYS = new Set(["stats", "tools"]);
+// configured_enabled duplicates api_url_configured on tibo_reset and would
+// render two identical rows on the card.
+const HIDDEN_RUNTIME_KEYS = new Set(["stats", "tools", "configured_enabled"]);
+
+function pluginRuntimeUnconfigured(
+  pluginName: string,
+  runtime?: PluginRuntime,
+): boolean {
+  const facts = runtime?.[pluginName as keyof PluginRuntime] as
+    | Record<string, unknown>
+    | undefined;
+  if (!facts) return false;
+  if (facts.api_url_configured === false) return true;
+  if (facts.api_key_configured === false) return true;
+  // A plugin with a working fallback endpoint (e.g. draw) is still usable
+  // when only the primary endpoint is missing.
+  return facts.configured === false && facts.fallback_configured !== true;
+}
 
 export function pluginEnablementLabel(
   plugin: InstalledPlugin | undefined,
@@ -520,7 +539,7 @@ export function pluginEnablementLabel(
   if (!plugin) return "未加载";
   if (plugin.restart_required) return "待重启";
   if (!plugin.enabled) return "已停用";
-  if (plugin.name === "tibo_reset" && runtime?.tibo_reset?.api_url_configured === false) {
+  if (pluginRuntimeUnconfigured(plugin.name, runtime)) {
     return "未配置";
   }
   return "已启用";
@@ -544,7 +563,7 @@ export function pluginRuntimeFacts(
 
 function formatRuntimeFact(key: string, value: unknown): string {
   if (typeof value === "boolean") {
-    if (key.endsWith("_configured") || key === "configured_enabled") {
+    if (key === "configured" || key.endsWith("_configured")) {
       return value ? "已配置" : "未配置";
     }
     return value ? "是" : "否";

--- a/frontend/src/pages/plugins/models.ts
+++ b/frontend/src/pages/plugins/models.ts
@@ -89,6 +89,9 @@ export type PluginRuntime = {
   tibo_reset?: {
     running?: boolean;
     scheduler_enabled?: boolean;
+    configured_enabled?: boolean;
+    api_url_configured?: boolean;
+    poll_interval_seconds?: number;
     enabled_groups?: number;
     latest_tweet_id?: string;
     last_success_at?: string;
@@ -483,3 +486,72 @@ export const PLUGIN_LINKS: Record<string, string> = {
   repeater: "/repeater",
   wxbot: "/wxbot",
 };
+
+export const PLUGIN_DISPLAY_NAMES: Record<string, string> = {
+  amap: "高德地图",
+  commands: "命令中心",
+  credits: "积分运营",
+  memory: "成员记忆",
+  moderation: "内容审核",
+  wxbot: "微信适配器",
+  persona_extract: "回复风格",
+  repeater: "复读策略",
+  tibo_reset: "Tibo 重置",
+};
+
+const PLUGIN_RUNTIME_FIELD_LABELS: Record<string, string> = {
+  api_url_configured: "接口地址",
+  configured_enabled: "密钥已配置",
+  scheduler_enabled: "调度器",
+  running: "运行中",
+  poll_interval_seconds: "轮询间隔（秒）",
+  last_error: "最近错误",
+  last_success_at: "最近成功",
+  latest_tweet_id: "最新条目",
+  enabled_groups: "已开群数",
+};
+
+const HIDDEN_RUNTIME_KEYS = new Set(["stats", "tools"]);
+
+export function pluginEnablementLabel(
+  plugin: InstalledPlugin | undefined,
+  runtime?: PluginRuntime,
+): string {
+  if (!plugin) return "未加载";
+  if (plugin.restart_required) return "待重启";
+  if (!plugin.enabled) return "已停用";
+  if (plugin.name === "tibo_reset" && runtime?.tibo_reset?.api_url_configured === false) {
+    return "未配置";
+  }
+  return "已启用";
+}
+
+export function pluginRuntimeFacts(
+  pluginName: string,
+  runtime: PluginRuntime,
+): Array<{ label: string; value: string }> {
+  const raw = runtime[pluginName as keyof PluginRuntime];
+  if (!raw || typeof raw !== "object") {
+    return [];
+  }
+  return Object.entries(raw)
+    .filter(([key, value]) => !HIDDEN_RUNTIME_KEYS.has(key) && value != null && typeof value !== "object")
+    .map(([key, value]) => ({
+      label: PLUGIN_RUNTIME_FIELD_LABELS[key] || key,
+      value: formatRuntimeFact(key, value),
+    }));
+}
+
+function formatRuntimeFact(key: string, value: unknown): string {
+  if (typeof value === "boolean") {
+    if (key.endsWith("_configured") || key === "configured_enabled") {
+      return value ? "已配置" : "未配置";
+    }
+    return value ? "是" : "否";
+  }
+  if (typeof value === "number" || typeof value === "string") {
+    const text = String(value).trim();
+    return text || "-";
+  }
+  return "-";
+}

--- a/frontend/src/pages/plugins/usePluginsPageController.ts
+++ b/frontend/src/pages/plugins/usePluginsPageController.ts
@@ -361,7 +361,7 @@ export function usePluginsPageController() {
       const result = await apiRequest<{ restart_required?: boolean }>(
         config,
         "/v1/admin/runtime/restart-instructions",
-        { auth: true, method: "POST" },
+        { auth: true, init: { method: "POST" } },
       );
       setRestartRequired(Boolean(result.restart_required));
     } catch {
@@ -629,7 +629,7 @@ export function usePluginsPageController() {
           await loadGroups();
         }
         await loadPluginEvents();
-        await loadRestartInstructions(plugins);
+        await loadRestartInstructions(installedResult.plugins || []);
         await loadFlowRuntimeStatus();
       })().catch((err: unknown) => {
         setError(err instanceof Error ? err.message : "加载失败");

--- a/frontend/src/pages/plugins/usePluginsPageController.ts
+++ b/frontend/src/pages/plugins/usePluginsPageController.ts
@@ -68,6 +68,8 @@ export function usePluginsPageController() {
   const [traceAggregateError, setTraceAggregateError] = useState("");
   const [flowLoading, setFlowLoading] = useState(false);
   const [flowError, setFlowError] = useState("");
+  const [restartRequired, setRestartRequired] = useState(false);
+  const selectedPluginName = searchParams.get("plugin")?.trim() || "";
 
   const pluginCards: InstalledPlugin[] = installed.length ? installed : (data?.plugins || []).map((plugin) => ({
     ...plugin,
@@ -98,6 +100,7 @@ export function usePluginsPageController() {
         await loadGroups();
       }
       await loadPluginEvents();
+      await loadRestartInstructions(installedResult.plugins || []);
       await loadFlowRuntimeStatus();
     } catch (err) {
       setError(err instanceof Error ? err.message : "加载失败");
@@ -342,6 +345,27 @@ export function usePluginsPageController() {
       setPluginEvents(result.events || []);
     } catch {
       setPluginEvents([]);
+    }
+  };
+
+  const loadRestartInstructions = async (plugins: Array<{ restart_required?: boolean }>) => {
+    if (plugins.some((plugin) => plugin.restart_required)) {
+      setRestartRequired(true);
+      return;
+    }
+    if (!config.adminToken) {
+      setRestartRequired(false);
+      return;
+    }
+    try {
+      const result = await apiRequest<{ restart_required?: boolean }>(
+        config,
+        "/v1/admin/runtime/restart-instructions",
+        { auth: true, method: "POST" },
+      );
+      setRestartRequired(Boolean(result.restart_required));
+    } catch {
+      setRestartRequired(false);
     }
   };
 
@@ -605,6 +629,7 @@ export function usePluginsPageController() {
           await loadGroups();
         }
         await loadPluginEvents();
+        await loadRestartInstructions(plugins);
         await loadFlowRuntimeStatus();
       })().catch((err: unknown) => {
         setError(err instanceof Error ? err.message : "加载失败");
@@ -626,6 +651,16 @@ export function usePluginsPageController() {
       setManagedGroupSessionId(nextGroupSessionId);
     }
   }, [config.sessionId, managedGroupSessionId]);
+
+  useEffect(() => {
+    if (!selectedPluginName) {
+      return;
+    }
+    const card = document.getElementById(`plugin-card-${selectedPluginName}`);
+    if (card && typeof card.scrollIntoView === "function") {
+      card.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [selectedPluginName, pluginCards.length]);
 
   useEffect(() => {
     const nextTraceId = searchParams.get("trace_id")?.trim() || "";
@@ -736,6 +771,8 @@ export function usePluginsPageController() {
     traceAggregateError,
     flowLoading,
     flowError,
+    selectedPluginName,
+    restartRequired,
     refreshSummary: loadSummary,
     refreshFlowRuntime: loadFlowRuntimeStatus,
     selectEffectTrace,

--- a/frontend/src/pages/relationship-graph/RelationshipActionPanel.tsx
+++ b/frontend/src/pages/relationship-graph/RelationshipActionPanel.tsx
@@ -7,10 +7,6 @@ import {
 export function RelationshipActionPanel(controller: RelationshipGraphController) {
   const {
     actionPanelOpen,
-    setActionPanelOpen,
-    loadGraph,
-    loading,
-    showAllGraph,
     extracting,
     extractionBatchLimit,
     setExtractionBatchLimit,
@@ -31,120 +27,98 @@ export function RelationshipActionPanel(controller: RelationshipGraphController)
     windowExtractionCursor,
   } = controller;
 
+  if (!actionPanelOpen) return null;
+
   return (
-      <section className={`panel relationship-action-panel${actionPanelOpen ? " is-open" : ""}`} aria-label="关系图操作">
-        <div className="relationship-action-bar">
-          <div className="relationship-action-copy">
-            <p className="section-kicker">操作</p>
-            <h3>关系图控制台</h3>
-            <span>历史导入、AI 抽取任务和图谱读取分开执行；此页不显示原始聊天内容。</span>
-          </div>
-          <div className="relationship-action-group">
-            <span>图谱</span>
-            <button className="button button-primary" type="button" onClick={() => void loadGraph()} disabled={loading}>
-              {loading ? "加载中" : "刷新关系图"}
-            </button>
-            <button className="button button-secondary" type="button" onClick={() => void showAllGraph()} disabled={loading}>
-              显示全部关系
-            </button>
-          </div>
-          <button
-            className="button button-secondary relationship-action-toggle"
-            type="button"
-            onClick={() => setActionPanelOpen((open) => !open)}
-            aria-expanded={actionPanelOpen}
-          >
-            {actionPanelOpen ? "收起抽取控制" : "抽取控制"}
-          </button>
+    <section className="panel relationship-action-panel is-open" aria-label="关系图操作">
+      <div className="relationship-action-groups">
+        <RelationshipMutationActions controller={controller} />
+        <div className="relationship-action-group relationship-extraction-controls">
+          <span>AI 批处理</span>
+          <label className="relationship-inline-control">
+            <small>每批上限</small>
+            <select
+              value={extractionBatchLimit}
+              onChange={(event) => setExtractionBatchLimit(event.target.value)}
+              disabled={extracting}
+            >
+              <option value="20">20</option>
+              <option value="50">50</option>
+              <option value="100">100</option>
+            </select>
+          </label>
+          <label className="relationship-inline-check">
+            <input
+              type="checkbox"
+              checked={extractionContinuous}
+              onChange={(event) => setExtractionContinuous(event.target.checked)}
+              disabled={extracting}
+            />
+            <small>连续</small>
+          </label>
+          <label className="relationship-inline-control">
+            <small>任务上限</small>
+            <input
+              type="number"
+              min="1"
+              max="500"
+              value={extractionMaxJobs}
+              onChange={(event) => setExtractionMaxJobs(event.target.value)}
+              disabled={extracting || !extractionContinuous}
+            />
+          </label>
+          <em>待处理 {selectedJobStats.pending}，约 {estimatedExtractionClicks || 0} 次</em>
         </div>
-        <div className="relationship-action-groups" hidden={!actionPanelOpen}>
-          <RelationshipMutationActions controller={controller} />
-          <div className="relationship-action-group relationship-extraction-controls">
-            <span>AI 批处理</span>
-            <label className="relationship-inline-control">
-              <small>每批上限</small>
-              <select
-                value={extractionBatchLimit}
-                onChange={(event) => setExtractionBatchLimit(event.target.value)}
-                disabled={extracting}
-              >
-                <option value="20">20</option>
-                <option value="50">50</option>
-                <option value="100">100</option>
-              </select>
-            </label>
-            <label className="relationship-inline-check">
-              <input
-                type="checkbox"
-                checked={extractionContinuous}
-                onChange={(event) => setExtractionContinuous(event.target.checked)}
-                disabled={extracting}
-              />
-              <small>连续</small>
-            </label>
-            <label className="relationship-inline-control">
-              <small>任务上限</small>
-              <input
-                type="number"
-                min="1"
-                max="500"
-                value={extractionMaxJobs}
-                onChange={(event) => setExtractionMaxJobs(event.target.value)}
-                disabled={extracting || !extractionContinuous}
-              />
-            </label>
-            <em>待处理 {selectedJobStats.pending}，约 {estimatedExtractionClicks || 0} 次</em>
-          </div>
-          <div className="relationship-action-group relationship-extraction-controls">
-            <span>窗口抽取</span>
-            <label className="relationship-inline-control">
-              <small>窗口大小</small>
-              <select
-                value={windowExtractionSize}
-                onChange={(event) => setWindowExtractionSize(event.target.value)}
-                disabled={extracting}
-              >
-                <option value="30">30</option>
-                <option value="50">50</option>
-                <option value="80">80</option>
-              </select>
-            </label>
-            <label className="relationship-inline-control">
-              <small>窗口上限</small>
-              <select
-                value={windowExtractionMaxWindows}
-                onChange={(event) => setWindowExtractionMaxWindows(event.target.value)}
-                disabled={extracting}
-              >
-                <option value="1">1</option>
-                <option value="3">3</option>
-                <option value="5">5</option>
-              </select>
-            </label>
-            <label className="relationship-inline-control">
-              <small>追平上限</small>
-              <input
-                type="number"
-                min="1"
-                max="100"
-                value={windowCatchupMaxWindows}
-                onChange={(event) => setWindowCatchupMaxWindows(event.target.value)}
-                disabled={extracting}
-              />
-            </label>
-            <label className="relationship-inline-check">
-              <input
-                type="checkbox"
-                checked={windowExtractionDryRun}
-                onChange={(event) => setWindowExtractionDryRun(event.target.checked)}
-                disabled={extracting}
-              />
-              <small>仅演练</small>
-            </label>
-            <em>当前游标 {windowExtractionCursor}</em>
-          </div>
-          <RelationshipUnavailableReset />
+        <div className="relationship-action-group relationship-extraction-controls">
+          <span>窗口抽取</span>
+          <label className="relationship-inline-control">
+            <small>窗口大小</small>
+            <select
+              value={windowExtractionSize}
+              onChange={(event) => setWindowExtractionSize(event.target.value)}
+              disabled={extracting}
+            >
+              <option value="30">30</option>
+              <option value="50">50</option>
+              <option value="80">80</option>
+            </select>
+          </label>
+          <label className="relationship-inline-control">
+            <small>窗口上限</small>
+            <select
+              value={windowExtractionMaxWindows}
+              onChange={(event) => setWindowExtractionMaxWindows(event.target.value)}
+              disabled={extracting}
+            >
+              <option value="1">1</option>
+              <option value="3">3</option>
+              <option value="5">5</option>
+            </select>
+          </label>
+          <label className="relationship-inline-control">
+            <small>追平上限</small>
+            <input
+              type="number"
+              min="1"
+              max="100"
+              value={windowCatchupMaxWindows}
+              onChange={(event) => setWindowCatchupMaxWindows(event.target.value)}
+              disabled={extracting}
+            />
+          </label>
+          <label className="relationship-inline-check">
+            <input
+              type="checkbox"
+              checked={windowExtractionDryRun}
+              onChange={(event) => setWindowExtractionDryRun(event.target.checked)}
+              disabled={extracting}
+            />
+            <small>仅演练</small>
+          </label>
+          <em>当前游标 {windowExtractionCursor}</em>
         </div>
-      </section>
+        <RelationshipUnavailableReset />
+      </div>
+    </section>
   );
 }

--- a/frontend/src/pages/relationship-graph/RelationshipDetailsAndDanger.tsx
+++ b/frontend/src/pages/relationship-graph/RelationshipDetailsAndDanger.tsx
@@ -282,8 +282,8 @@ export function RelationshipHistorySummary(controller: RelationshipGraphControll
         </div>
       </section>
 
-      <OutputPanel title="历史同步调试 JSON" value={syncOutput} />
-      <OutputPanel title="关系图响应摘要 JSON" value={output} />
+      <OutputPanel flush title="历史同步调试 JSON" value={syncOutput} />
+      <OutputPanel flush title="关系图响应摘要 JSON" value={output} />
     </>
   );
 }

--- a/frontend/src/pages/relationship-graph/RelationshipFiltersAndStatus.tsx
+++ b/frontend/src/pages/relationship-graph/RelationshipFiltersAndStatus.tsx
@@ -16,7 +16,6 @@ import type { RelationshipGraphController } from "./useRelationshipGraphControll
 export function RelationshipFiltersAndStatus(controller: RelationshipGraphController) {
   const {
     config,
-    selectedGroupIsVerified,
     channel,
     setChannel,
     sourceKey,
@@ -67,20 +66,15 @@ export function RelationshipFiltersAndStatus(controller: RelationshipGraphContro
 
   return (
     <>
-      <section className="panel relationship-filters">
-        <div className="panel-header">
-          <div>
+      <details className="panel relationship-filters relationship-disclosure">
+        <summary>
+          <span>
             <p className="section-kicker">筛选</p>
             <h3>群聊关系查询</h3>
-          </div>
-          <span className="relationship-panel-note">常用操作位于上方关系图控制台。</span>
-        </div>
+          </span>
+          <span className="relationship-disclosure-hint">展开</span>
+        </summary>
         <div className="form-grid relationship-filter-grid">
-          <div className="field">
-            <span>已验证群聊范围</span>
-            <strong>{selectedGroupIsVerified ? "已选择授权群聊" : "尚未选择"}</strong>
-            <small>租户由登录身份确定，群聊只能从页面上方的后端名册选择。</small>
-          </div>
           <label className="field">
             <span>消息渠道</span>
             <input value={channel} onChange={(event) => setChannel(event.target.value)} />
@@ -139,43 +133,27 @@ export function RelationshipFiltersAndStatus(controller: RelationshipGraphContro
         <p className="relationship-query-note">
           时间范围会发送给服务端；节点和关系搜索只在安全图谱摘要上本地过滤，不读取原始聊天内容。
         </p>
-      </section>
+      </details>
 
-      <section className="panel relationship-history-sync">
-        <div className="panel-header">
-          <div>
+      <details className="panel relationship-history-sync relationship-disclosure">
+        <summary>
+          <span>
             <p className="section-kicker">历史同步</p>
             <h3>按日期同步群聊历史</h3>
-            <p className="relationship-section-description">
-              导入某一天的历史消息，并可选择自动排队 AI 抽取任务；任务处理成功后关系图才会更新。
-            </p>
-          </div>
-          <span className="relationship-panel-note">主要按钮固定在顶部控制台。</span>
-        </div>
-        <ol className="relationship-sync-guide" aria-label="历史同步三步操作">
-          <li><strong>1</strong><span>从已验证列表选择群聊</span></li>
-          <li><strong>2</strong><span>导入所选日期历史</span></li>
-          <li><strong>3</strong><span>查看AI任务和图谱状态</span></li>
-        </ol>
-        <p className="relationship-sync-hint" role="note">
-          群聊模式：无需填写用户ID。
+          </span>
+          <span className="relationship-disclosure-hint">展开</span>
+        </summary>
+        <p className="relationship-section-description">
+          导入某一天的历史消息，并可选择自动排队 AI 抽取任务；任务处理成功后关系图才会更新。
         </p>
         <p className={`relationship-sync-hint${missingHistorySyncFields.length ? " is-warning" : ""}`} role="status">
           {historySyncHint}
         </p>
-        <div className="relationship-scope-strip" aria-label="当前补算范围">
-          <span>当前范围：<strong>{selectedGroupIsVerified ? "已验证群聊及其授权成员" : "尚未选择群聊"}</strong></span>
-          <TechnicalDetails
-            summary="查看补算范围技术详情"
-            value={{ tenant_id: config.tenantId, channel, source_key: sourceKey, session_id: config.sessionId, user_scope: optionalUserScopeLabel }}
-          />
-        </div>
+        <TechnicalDetails
+          summary="查看补算范围技术详情"
+          value={{ tenant_id: config.tenantId, channel, source_key: sourceKey, session_id: config.sessionId, user_scope: optionalUserScopeLabel }}
+        />
         <div className="form-grid relationship-sync-grid">
-          <div className="field">
-            {fieldLabel("当前群聊", "verified session_id")}
-            <strong>{selectedGroupIsVerified ? "已选择授权群聊" : "尚未选择"}</strong>
-            <small>同步固定覆盖当前群获授权成员，不提供成员标识自由覆盖。</small>
-          </div>
           <label className="field">
             {fieldLabel("同步日期", "target_date")}
             <input
@@ -231,7 +209,7 @@ export function RelationshipFiltersAndStatus(controller: RelationshipGraphContro
             </p>
           )}
         </div>
-      </section>
+      </details>
 
       <section className="status-grid relationship-status-grid">
         <StatusTile label="数据版本" value={graph?.schema?.version || "-"} />
@@ -239,7 +217,15 @@ export function RelationshipFiltersAndStatus(controller: RelationshipGraphContro
         <StatusTile label="关系" value={`${graphEdges.length} / ${graph?.counts?.edges ?? edges.length}`} />
       </section>
 
-      <section className="panel relationship-job-summary" aria-label="智能关系抽取任务状态">
+      <details className="panel relationship-disclosure">
+        <summary>
+          <span>
+            <p className="section-kicker">任务计数</p>
+            <h3>抽取任务与窗口统计</h3>
+          </span>
+          <span className="relationship-disclosure-hint">展开</span>
+        </summary>
+      <section className="relationship-job-summary" aria-label="智能关系抽取任务状态">
         <div className="relationship-job-summary-header">
           <div>
             <p className="section-kicker">智能关系抽取任务</p>
@@ -260,7 +246,7 @@ export function RelationshipFiltersAndStatus(controller: RelationshipGraphContro
         </div>
       </section>
 
-      <section className="panel relationship-job-summary" aria-label="时间窗关系抽取统计">
+      <section className="relationship-job-summary" aria-label="时间窗关系抽取统计">
         <div className="relationship-job-summary-header">
           <div>
             <p className="section-kicker">时间窗抽取</p>
@@ -279,6 +265,7 @@ export function RelationshipFiltersAndStatus(controller: RelationshipGraphContro
           <div><span>已拒绝</span><strong>{windowStatsAcceptance.rejected ?? 0}</strong></div>
         </div>
       </section>
+      </details>
     </>
   );
 }

--- a/frontend/src/pages/relationship-graph/RelationshipGraphWorkspace.tsx
+++ b/frontend/src/pages/relationship-graph/RelationshipGraphWorkspace.tsx
@@ -1,3 +1,4 @@
+import { GroupScopeEmpty } from "../../components/GroupScopeEmpty";
 import { PageHeader } from "../../components/PageHeader";
 import { RelationshipActionPanel } from "./RelationshipActionPanel";
 import {
@@ -11,22 +12,50 @@ import { useRelationshipGraphController } from "./useRelationshipGraphController
 export function RelationshipGraphWorkspace() {
   const controller = useRelationshipGraphController();
 
+  if (!controller.selectedGroupIsVerified) {
+    return (
+      <GroupScopeEmpty
+        eyebrow="关系记忆可视化"
+        title="群聊关系图"
+        description="以只读方式展示当前群的关系记忆，包括审核状态与证据引用，不展示聊天原文。"
+      />
+    );
+  }
+
   return (
     <div className="relationship-graph-page">
       <PageHeader
         eyebrow="关系记忆可视化"
-        title="Relationship Graph / 群聊关系图"
-        description="以只读方式展示当前群的关系记忆，包括审核状态与证据引用，不展示聊天原文。"
+        title="群聊关系图"
+        description="只读展示当前群的关系记忆与审核状态，不展示聊天原文。"
+        actions={
+          <div className="action-row">
+            <button className="button button-primary" type="button" onClick={() => void controller.loadGraph()} disabled={controller.loading}>
+              {controller.loading ? "加载中" : "刷新关系图"}
+            </button>
+            <button className="button button-secondary" type="button" onClick={() => void controller.showAllGraph()} disabled={controller.loading}>
+              显示全部关系
+            </button>
+            <button
+              className="button button-secondary"
+              type="button"
+              onClick={() => controller.setActionPanelOpen((open) => !open)}
+              aria-expanded={controller.actionPanelOpen}
+            >
+              {controller.actionPanelOpen ? "收起抽取控制" : "抽取控制"}
+            </button>
+          </div>
+        }
       />
 
       <RelationshipActionPanel {...controller} />
-      <RelationshipFiltersAndStatus {...controller} />
 
       <div className="relationship-workbench">
         <RelationshipGraphPresentation {...controller} />
         <RelationshipDetailPanel {...controller} />
       </div>
 
+      <RelationshipFiltersAndStatus {...controller} />
       <RelationshipHistorySummary {...controller} />
     </div>
   );

--- a/frontend/src/pages/wxbot/WxbotAgentTab.tsx
+++ b/frontend/src/pages/wxbot/WxbotAgentTab.tsx
@@ -75,17 +75,20 @@ export function WxbotAgentTab({ controller }: { controller: WxbotPageController 
                 <strong>{agentToolOwners.length || "-"}</strong>
               </div>
             </div>
-            <div className="route-list">
-              <div>当前智能体支持多个作用域；会根据群聊意图切到资料查询、插件状态或绘图生成，不替代普通回复策略。</div>
-              <div>工具白名单按群生效，沿用顶部“全局目标群 / 会话”或左侧群列表的当前选中群。</div>
-              <div>未配置过的群默认启用并继承当前作用域的全部工具；只有明确停用或保存手动白名单才会覆盖默认值。</div>
-              <div>文件处理与消息导出还受“群行为 → 允许群文件发送”总开关约束；总开关关闭时，管理员也不能绕过。</div>
-              <div>如果当前群关闭智能体，后端会直接返回“该群智能体能力已关闭”，不会再回落到普通模型工具调用。</div>
-              <div>工具目录会标明插件归属，后续继续拆分作用域和插件能力时，可直接看出工具来源。</div>
-            </div>
+            <details className="credits-help-disclosure">
+              <summary>工具白名单说明</summary>
+              <p className="muted-copy">
+                当前智能体支持多个作用域；会根据群聊意图切到资料查询、插件状态或绘图生成，不替代普通回复策略。
+                工具白名单按群生效，沿用顶部“全局目标群 / 会话”或左侧群列表的当前选中群。
+                未配置过的群默认启用并继承当前作用域的全部工具；只有明确停用或保存手动白名单才会覆盖默认值。
+                文件处理与消息导出还受“群行为 → 允许群文件发送”总开关约束；总开关关闭时，管理员也不能绕过。
+                如果当前群关闭智能体，后端会直接返回“该群智能体能力已关闭”，不会再回落到普通模型工具调用。
+                工具目录会标明插件归属，后续继续拆分作用域和插件能力时，可直接看出工具来源。
+              </p>
+            </details>
           </section>
 
-          <section className="panel span-2">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">工具策略</p>
@@ -213,7 +216,7 @@ export function WxbotAgentTab({ controller }: { controller: WxbotPageController 
             )}
           </section>
 
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">策略快照</p>
@@ -352,7 +355,7 @@ export function WxbotAgentTab({ controller }: { controller: WxbotPageController 
             </div>
           </section>
 
-          <OutputPanel title="智能体策略 / 审计响应" value={agentOutput} />
+          <OutputPanel flush title="智能体策略 / 审计响应" value={agentOutput} />
         </>
       );
 }

--- a/frontend/src/pages/wxbot/WxbotEventsTab.tsx
+++ b/frontend/src/pages/wxbot/WxbotEventsTab.tsx
@@ -51,7 +51,7 @@ export function WxbotEventsTab({ controller }: { controller: WxbotPageController
 
   return (
         <>
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">成员事件 Webhook</p>
@@ -172,7 +172,7 @@ export function WxbotEventsTab({ controller }: { controller: WxbotPageController
             </div>
           </section>
 
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">欢迎语</p>
@@ -316,8 +316,8 @@ export function WxbotEventsTab({ controller }: { controller: WxbotPageController
             </div>
           </section>
 
-          <OutputPanel title="事件订阅 / 成员事件响应" value={eventOutput} />
-          <OutputPanel title="群欢迎语响应" value={groupOutput} />
+          <OutputPanel flush title="事件订阅 / 成员事件响应" value={eventOutput} />
+          <OutputPanel flush title="群欢迎语响应" value={groupOutput} />
         </>
       );
 }

--- a/frontend/src/pages/wxbot/WxbotOverviewTab.tsx
+++ b/frontend/src/pages/wxbot/WxbotOverviewTab.tsx
@@ -13,7 +13,7 @@ export function WxbotOverviewTab({ controller }: { controller: WxbotPageControll
 
   return (
         <>
-          <section className="panel span-2">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">桥接服务</p>
@@ -88,24 +88,17 @@ export function WxbotOverviewTab({ controller }: { controller: WxbotPageControll
               </tbody>
             </table>
             </details>
+            <details>
+              <summary>当前接入说明</summary>
+              <ul className="route-list">
+                <li>群聊是否必须先 @机器人 才会进入系统，取决于 SDK 侧“群消息必须 @我 才入站”开关。</li>
+                <li>“包含触发词”模式既支持 @我，也支持关键词命中，并非只识别 @。</li>
+                <li>群聊默认关闭回复；如果会话设为“全部消息”或“包含触发词”，可能在没有 @ 的场景下触发回复。</li>
+                <li>日报/周报/月报数据直接来自本地微信解密数据库，适合按群做定时发送和人工预览发送。</li>
+              </ul>
+            </details>
+            <OutputPanel flush title="微信桥接响应" value={output} />
           </section>
-
-          <section className="panel">
-            <div className="panel-header">
-              <div>
-                <p className="section-kicker">接入范围</p>
-                <h3>当前接入说明</h3>
-              </div>
-            </div>
-            <ul className="route-list">
-              <li>群聊是否必须先 @机器人 才会进入系统，取决于 SDK 侧“群消息必须 @我 才入站”开关。</li>
-              <li>“包含触发词”模式既支持 @我，也支持关键词命中，并非只识别 @。</li>
-              <li>群聊默认关闭回复；如果会话设为“全部消息”或“包含触发词”，可能在没有 @ 的场景下触发回复。</li>
-              <li>日报/周报/月报数据直接来自本地微信解密数据库，适合按群做定时发送和人工预览发送。</li>
-            </ul>
-          </section>
-
-          <OutputPanel title="微信桥接响应" value={output} />
         </>
       );
 }

--- a/frontend/src/pages/wxbot/WxbotPageView.tsx
+++ b/frontend/src/pages/wxbot/WxbotPageView.tsx
@@ -49,23 +49,29 @@ export function WxbotPageView() {
         <PageHeader
           eyebrow="微信机器人"
           title="微信机器人桥接"
-          description="统一管理桥接状态、会话回复策略、群成员事件、欢迎语和日报周报月报订阅。报表由本地微信解密数据库生成，不依赖平台留存对话轮次。"
+          description="桥接状态、回复策略、群成员事件和报表订阅；报表由本地微信解密库生成。"
+          actions={
+            <div className="action-row">
+              <button className="button button-primary" onClick={() => void refresh()} disabled={loading}>
+                {loading ? "刷新中..." : "刷新桥接状态"}
+              </button>
+            </div>
+          }
         />
-        <div className="action-row">
-          <button className="button button-primary" onClick={() => void refresh()} disabled={loading}>
-            {loading ? "刷新中..." : "刷新桥接状态"}
-          </button>
-          <button className="button button-secondary" onClick={() => void loadReplyPolicy()}>
-            读取回复策略
-          </button>
-          <button className="button button-secondary" onClick={() => void loadMemberEvents()}>
-            读取成员事件
-          </button>
-          <button className="button button-secondary" onClick={() => void loadReportSubscriptions()}>
-            读取日报周报月报
-          </button>
+        <div className="page-ops-bar">
+          <div className="action-row">
+            <button className="button button-secondary button-compact" onClick={() => void loadReplyPolicy()}>
+              读取回复策略
+            </button>
+            <button className="button button-secondary button-compact" onClick={() => void loadMemberEvents()}>
+              读取成员事件
+            </button>
+            <button className="button button-secondary button-compact" onClick={() => void loadReportSubscriptions()}>
+              读取日报周报月报
+            </button>
+          </div>
         </div>
-        <div className="summary-grid">
+        <div className="summary-grid page-hero-metrics">
           <div
             className="summary-card"
             data-status={bridgeStatus ? (bridgeStatus.running ? "ok" : "error") : error ? "error" : undefined}

--- a/frontend/src/pages/wxbot/WxbotPolicyTab.tsx
+++ b/frontend/src/pages/wxbot/WxbotPolicyTab.tsx
@@ -91,19 +91,16 @@ export function WxbotPolicyTab({ controller }: { controller: WxbotPageController
 
   return (
         <>
-          <section className="panel span-2">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">快速配置</p>
                 <h3>简化回复配置</h3>
               </div>
             </div>
-            <div className="route-list">
-              <div>目标效果：私聊直接回复，群里只有 @机器人 才回复。</div>
-              <div>系统会在一个事务中校验并写入全局策略、当前群会话策略、复读策略与 SDK 入站门禁；任一版本冲突都不会部分生效。</div>
-              <div>当前群参与总开关是独立的最终闸门：新群默认开启，明确关闭过的群需在下方重新开启。</div>
-              <div>这样群聊侧是否回复，主要由 SDK 的“必须 @我才入站”开关决定；只要没有 @机器人，消息不会进入控制台。</div>
-            </div>
+            <p className="muted-copy">
+              目标效果：私聊直接回复，群里只有 @机器人 才回复。系统会在一个事务中校验并写入全局策略、当前群会话策略、复读策略与 SDK 入站门禁；任一版本冲突都不会部分生效。当前群参与总开关是独立的最终闸门：新群默认开启，明确关闭过的群需在下方重新开启。群聊侧是否回复，主要由 SDK 的“必须 @我才入站”开关决定；只要没有 @机器人，消息不会进入控制台。
+            </p>
             {policyConflict ? (
               <Alert variant="warning" title="策略版本冲突">
                 本地草稿仍在。请使用对应区域的“放弃草稿并重新读取”，核对服务端新版本后再保存。
@@ -130,7 +127,7 @@ export function WxbotPolicyTab({ controller }: { controller: WxbotPageController
             </div>
           </section>
 
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">全局策略</p>
@@ -185,7 +182,7 @@ export function WxbotPolicyTab({ controller }: { controller: WxbotPageController
             </p>
           </section>
 
-          <section className="panel span-2">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">会话覆盖</p>
@@ -646,7 +643,7 @@ export function WxbotPolicyTab({ controller }: { controller: WxbotPageController
             )}
           </section>
 
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">会话状态</p>
@@ -725,7 +722,7 @@ export function WxbotPolicyTab({ controller }: { controller: WxbotPageController
             </p>
           </section>
 
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">SDK 入站门禁</p>
@@ -762,7 +759,7 @@ export function WxbotPolicyTab({ controller }: { controller: WxbotPageController
             </p>
           </section>
 
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">策略说明</p>
@@ -789,7 +786,7 @@ export function WxbotPolicyTab({ controller }: { controller: WxbotPageController
             </ul>
           </section>
 
-          <OutputPanel title="回复策略响应" value={policyOutput} />
+          <OutputPanel flush title="回复策略响应" value={policyOutput} />
         </>
       );
 }

--- a/frontend/src/pages/wxbot/WxbotReportsTab.tsx
+++ b/frontend/src/pages/wxbot/WxbotReportsTab.tsx
@@ -82,7 +82,7 @@ export function WxbotReportsTab({ controller }: { controller: WxbotPageControlle
 
   return (
         <>
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">质量复盘</p>
@@ -245,7 +245,7 @@ export function WxbotReportsTab({ controller }: { controller: WxbotPageControlle
             </div>
           </section>
 
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">定时计划</p>
@@ -399,7 +399,7 @@ export function WxbotReportsTab({ controller }: { controller: WxbotPageControlle
             </div>
           </section>
 
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">手动操作</p>
@@ -453,7 +453,7 @@ export function WxbotReportsTab({ controller }: { controller: WxbotPageControlle
             </pre>
           </section>
 
-          <section className="panel span-2">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">历史记录</p>
@@ -522,7 +522,7 @@ export function WxbotReportsTab({ controller }: { controller: WxbotPageControlle
             </div>
           </section>
 
-          <section className="panel span-2">
+          <section className="panel span-3">
             <details>
               <summary>技术详情：日报原始消息</summary>
               <div className="panel-header">
@@ -586,8 +586,8 @@ export function WxbotReportsTab({ controller }: { controller: WxbotPageControlle
             </details>
           </section>
 
-          <OutputPanel title="日报 / 周报 / 月报响应" value={reportOutput} />
-          <OutputPanel title="自我迭代响应" value={selfReviewOutput} />
+          <OutputPanel flush title="日报 / 周报 / 月报响应" value={reportOutput} />
+          <OutputPanel flush title="自我迭代响应" value={selfReviewOutput} />
         </>
       );
 }

--- a/frontend/src/pages/wxbot/WxbotSendTab.tsx
+++ b/frontend/src/pages/wxbot/WxbotSendTab.tsx
@@ -32,7 +32,7 @@ export function WxbotSendTab({ controller }: { controller: WxbotPageController }
 
   return (
         <>
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">端到端测试</p>
@@ -48,7 +48,7 @@ export function WxbotSendTab({ controller }: { controller: WxbotPageController }
             </div>
           </section>
 
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">发送说明</p>
@@ -63,7 +63,7 @@ export function WxbotSendTab({ controller }: { controller: WxbotPageController }
             </ul>
           </section>
 
-          <section className="panel span-2">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">系统发送队列</p>
@@ -133,7 +133,7 @@ export function WxbotSendTab({ controller }: { controller: WxbotPageController }
             </div>
           </section>
 
-          <section className="panel">
+          <section className="panel span-3">
             <div className="panel-header">
               <div>
                 <p className="section-kicker">SDK 发送队列</p>
@@ -263,7 +263,7 @@ export function WxbotSendTab({ controller }: { controller: WxbotPageController }
             </div>
           </section>
 
-          <OutputPanel title="发送响应" value={actionOutput} />
+          <OutputPanel flush title="发送响应" value={actionOutput} />
         </>
       );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -9,10 +9,14 @@ html, body, #root {
 body {
   margin: 0;
   color: var(--text);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", sans-serif;
+  font-family: var(--font-body);
   font-size: var(--font-size-base);
   line-height: 1.5;
-  background: var(--bg);
+  background:
+    linear-gradient(rgba(29, 32, 28, 0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(29, 32, 28, 0.022) 1px, transparent 1px),
+    var(--bg);
+  background-size: 28px 28px, 28px 28px, auto;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -69,8 +73,21 @@ button {
 }
 
 .brand-block {
+  position: relative;
   padding: var(--space-6) var(--space-5) var(--space-5);
   border-bottom: 1px solid var(--sidebar-border);
+  background:
+    radial-gradient(circle at 0% 0%, rgba(45, 212, 191, 0.08), transparent 55%);
+}
+
+.brand-block::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 34px;
+  height: 2px;
+  background: var(--color-pine-400);
 }
 
 .brand-block h1 {
@@ -84,22 +101,39 @@ button {
 .sidebar-copy {
   margin: var(--space-1-5) 0 0;
   font-size: var(--font-size-xs);
-  color: var(--color-slate-400);
+  color: rgba(167, 179, 169, 0.72);
   line-height: 1.5;
 }
 
 .section-kicker {
-  margin: 0 0 var(--space-0-5);
-  color: var(--color-custom-5f6b7a);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  margin: 0 0 var(--space-1);
+  color: var(--accent);
   text-transform: uppercase;
+  font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.14em;
   font-weight: 600;
 }
 
+.section-kicker::before {
+  content: "";
+  width: 14px;
+  height: 2px;
+  flex-shrink: 0;
+  background: var(--accent);
+  opacity: 0.85;
+}
+
 .sidebar .section-kicker {
-  color: var(--color-slate-400);
+  color: rgba(167, 179, 169, 0.62);
   padding: var(--space-4) var(--space-5) var(--space-1-5);
+}
+
+.sidebar .section-kicker::before {
+  display: none;
 }
 
 /* ── Navigation ── */
@@ -112,6 +146,7 @@ button {
 }
 
 .nav-link {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--space-2-5);
@@ -131,6 +166,17 @@ button {
 .nav-link.active {
   background: var(--sidebar-active);
   color: var(--sidebar-active-text);
+}
+
+.nav-link.active::before {
+  content: "";
+  position: absolute;
+  left: -1px;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  border-radius: 1px;
+  background: var(--color-pine-400);
 }
 
 .nav-icon {
@@ -193,7 +239,7 @@ button {
 }
 
 .sidebar-config-body .field span {
-  color: rgba(148, 163, 184, 0.8);
+  color: rgba(167, 179, 169, 0.8);
   font-size: var(--font-size-xs);
 }
 
@@ -208,7 +254,7 @@ button {
 
 .sidebar-config-body .field input:focus-visible {
   border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.2);
 }
 
 .sidebar-config-body .action-row {
@@ -254,9 +300,9 @@ button {
   align-items: end;
   margin: 0 0 var(--space-4-5);
   padding: var(--space-3-5) var(--space-4);
-  border: 1px solid rgba(148, 163, 184, 0.22);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  background: rgba(251, 250, 245, 0.94);
   box-shadow: var(--shadow);
   backdrop-filter: blur(12px);
 }
@@ -268,10 +314,11 @@ button {
 }
 
 .global-session-kicker {
-  color: var(--text-muted);
-  font-size: var(--font-size-xs);
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-2xs);
+  font-weight: 600;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
@@ -349,18 +396,21 @@ button {
 
 .page-header {
   margin-bottom: var(--space-6);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--line);
 }
 
 .page-header h1 {
   margin: 0;
   font-size: var(--font-size-3xl);
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-weight: 800;
+  letter-spacing: -0.015em;
   color: var(--text);
 }
 
 .page-description {
-  margin: var(--space-1) 0 0;
+  margin: var(--space-1-5) 0 0;
+  max-width: 72ch;
   color: var(--text-secondary);
   font-size: var(--font-size-base);
 }
@@ -388,8 +438,10 @@ button {
 }
 
 .panel-hero {
-  background: linear-gradient(135deg, var(--color-slate-50) 0%, var(--color-indigo-50) 100%);
-  border-color: var(--color-indigo-100);
+  background:
+    radial-gradient(circle at 100% 0%, rgba(15, 118, 110, 0.06), transparent 42%),
+    var(--panel);
+  border-color: var(--line-strong);
 }
 
 .panel-sidebar {
@@ -494,7 +546,7 @@ button {
   overflow: visible;
   border: 1px solid var(--line);
   border-radius: calc(var(--radius-lg) - 2px);
-  background: linear-gradient(180deg, var(--color-slate-50) 0%, var(--color-slate-100) 100%);
+  background: linear-gradient(180deg, var(--panel-alt) 0%, var(--color-slate-100) 100%);
 }
 
 .group-behavior-tabs > .tabs-list .tabs-trigger {
@@ -510,14 +562,14 @@ button {
 }
 
 .group-behavior-tabs > .tabs-list .tabs-trigger:hover:not(:disabled) {
-  border-color: var(--color-custom-d7deea);
+  border-color: var(--line);
   background: rgba(255, 255, 255, 0.72);
   color: var(--text);
   transform: translateY(-1px);
 }
 
 .group-behavior-tabs > .tabs-list .tabs-trigger[aria-selected="true"] {
-  border-color: var(--color-indigo-200);
+  border-color: var(--line-strong);
   background: var(--panel);
   color: var(--text);
   box-shadow: 0 8px 18px rgba(30, 41, 59, 0.08), inset 0 0 0 1px rgba(255, 255, 255, 0.8);
@@ -546,18 +598,18 @@ button {
   width: 28px;
   height: 28px;
   place-items: center;
-  border: 1px solid var(--color-custom-dbe2ec);
+  border: 1px solid var(--line);
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.78);
   color: var(--text-muted);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
   font-weight: 700;
   letter-spacing: -0.02em;
 }
 
 .group-behavior-tabs .tabs-trigger[aria-selected="true"] .group-behavior-tab-index {
-  border-color: var(--color-indigo-200);
+  border-color: var(--line-strong);
   background: var(--accent-light);
   color: var(--accent-hover);
 }
@@ -589,15 +641,15 @@ button {
 }
 
 .release-controls-panel {
-  border-color: var(--color-custom-dbe3ef);
-  background: linear-gradient(180deg, var(--color-custom-fbfcfe) 0%, var(--color-slate-50) 100%);
+  border-color: var(--line);
+  background: linear-gradient(180deg, var(--panel) 0%, var(--panel-alt) 100%);
 }
 
 .release-control-card {
   padding: var(--space-4-5);
-  border-color: var(--color-custom-dbe3ef);
+  border-color: var(--line);
   background: rgba(255, 255, 255, 0.86);
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 1px 2px rgba(16, 25, 21, 0.04);
 }
 
 .release-control-card .panel-header {
@@ -937,35 +989,36 @@ button {
   border-radius: var(--radius);
   border: 1px solid transparent;
   font-size: var(--font-size-sm);
-  font-weight: 500;
-  transition: background 150ms, box-shadow 150ms, transform 100ms;
+  font-weight: 600;
+  transition: background 150ms, border-color 150ms, box-shadow 150ms, transform 100ms;
 }
 
 .button:active {
-  transform: scale(0.98);
+  transform: translateY(1px);
 }
 
 .button-primary {
-  color: white;
+  color: var(--color-paper-bright);
   background: var(--accent);
-  border-color: var(--accent);
-  box-shadow: var(--shadow-sm);
+  border-color: var(--accent-hover);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), var(--shadow-sm);
 }
 
 .button-primary:hover {
   background: var(--accent-hover);
-  box-shadow: var(--shadow);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), var(--shadow);
 }
 
 .button-secondary {
-  color: var(--text-secondary);
+  color: var(--text);
   background: var(--bg-surface);
-  border-color: var(--line);
+  border-color: var(--line-strong);
+  box-shadow: var(--shadow-sm);
 }
 
 .button-secondary:hover {
   background: var(--panel-alt);
-  border-color: var(--color-slate-300);
+  border-color: var(--color-ink-500);
 }
 
 .button-compact {
@@ -1040,7 +1093,7 @@ button {
   border-radius: 6px;
   background: var(--panel-alt);
   font-size: var(--font-size-sm);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: var(--font-mono);
   color: var(--text-secondary);
   word-break: break-all;
 }
@@ -1093,7 +1146,7 @@ button {
   margin-top: var(--space-4-5);
   padding: var(--space-3-5) var(--space-4);
   border-radius: var(--radius-lg);
-  border: 1px solid var(--color-indigo-100);
+  border: 1px solid var(--line);
   background: rgba(255, 255, 255, 0.72);
 }
 
@@ -1203,14 +1256,14 @@ button {
 }
 
 .knowledge-list-item:hover {
-  border-color: var(--color-slate-300);
+  border-color: var(--line-strong);
   box-shadow: var(--shadow-sm);
 }
 
 .knowledge-list-item.is-active {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-light);
-  background: var(--color-custom-f8faff);
+  background: var(--panel);
 }
 
 .knowledge-list-head {
@@ -1359,11 +1412,11 @@ button {
   min-height: 200px;
   max-height: 480px;
   overflow: auto;
-  background: var(--color-slate-800);
-  color: var(--color-slate-200);
-  border: 1px solid var(--color-slate-700);
+  background: var(--color-ink-sidebar-raised);
+  color: var(--color-sage-100);
+  border: 1px solid rgba(94, 234, 212, 0.14);
   line-height: 1.6;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: var(--font-mono);
   font-size: var(--font-size-sm);
 }
 
@@ -1498,8 +1551,8 @@ button {
   margin-bottom: var(--space-3-5);
   padding: var(--space-3) var(--space-3-5);
   border-radius: 10px;
-  border: 1px solid var(--color-custom-dbe7f3);
-  background: linear-gradient(135deg, var(--color-custom-f8fbff) 0%, var(--color-custom-eef6ff) 100%);
+  border: 1px solid var(--line);
+  background: linear-gradient(135deg, var(--panel) 0%, var(--panel-alt) 100%);
 }
 
 .agent-state-note strong {
@@ -1522,8 +1575,8 @@ button {
 
 .agent-tool-card.is-active {
   border-color: rgba(79, 70, 229, 0.24);
-  background: linear-gradient(180deg, var(--color-white) 0%, var(--color-custom-f5f7ff) 100%);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.08);
+  background: linear-gradient(180deg, var(--color-white) 0%, var(--panel-alt) 100%);
+  box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.08);
 }
 
 .agent-tool-card.is-disabled {
@@ -1632,7 +1685,7 @@ button {
   border-radius: 6px;
   background: var(--panel-alt);
   color: var(--text-secondary);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   line-height: 1.45;
   white-space: pre-wrap;
@@ -1789,14 +1842,28 @@ th, td {
 
 th {
   color: var(--text-muted);
+  font-family: var(--font-mono);
   font-weight: 600;
-  font-size: var(--font-size-xs);
+  font-size: var(--font-size-2xs);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
+  border-bottom-color: var(--line-strong);
+}
+
+td {
+  font-variant-numeric: tabular-nums;
+}
+
+tbody tr {
+  transition: background 100ms;
+}
+
+tbody tr:hover {
+  background: rgba(29, 32, 28, 0.025);
 }
 
 .mono {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: var(--font-mono);
   font-size: var(--font-size-xs);
 }
 
@@ -1834,8 +1901,10 @@ th {
   overflow: auto;
 }
 
-.table-row-active {
-  background: var(--color-custom-eef4ff);
+.table-row-active,
+tbody tr.table-row-active:hover {
+  background: var(--accent-light);
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 .table-cell-action {
@@ -1900,13 +1969,13 @@ th {
 .moderation-keyword-panel,
 .moderation-events-panel,
 .moderation-side-card {
-  border-color: var(--color-custom-dbe5f4);
+  border-color: var(--line);
 }
 
 .moderation-overview-panel {
   background:
     radial-gradient(circle at top right, rgba(14, 165, 233, 0.1), transparent 32%),
-    linear-gradient(135deg, var(--color-custom-f8fbff) 0%, var(--color-custom-eef6ff) 100%);
+    linear-gradient(135deg, var(--panel) 0%, var(--panel-alt) 100%);
 }
 
 .moderation-summary-grid {
@@ -1939,7 +2008,7 @@ th {
 
 .moderation-side-card {
   padding: var(--space-4-5);
-  background: linear-gradient(180deg, var(--color-white) 0%, var(--color-custom-f8fbff) 100%);
+  background: linear-gradient(180deg, var(--color-white) 0%, var(--panel) 100%);
   box-shadow: var(--shadow-sm);
 }
 
@@ -1957,7 +2026,7 @@ th {
   padding: var(--space-2-5) var(--space-3);
   border-radius: 10px;
   background: rgba(241, 245, 249, 0.88);
-  border: 1px solid var(--color-slate-200);
+  border: 1px solid var(--line);
 }
 
 .moderation-meta-list span,
@@ -2000,8 +2069,8 @@ th {
   margin-top: var(--space-3-5);
   padding: var(--space-3) var(--space-3-5);
   border-radius: 10px;
-  background: var(--color-slate-50);
-  border: 1px dashed var(--color-slate-300);
+  background: var(--panel-alt);
+  border: 1px dashed var(--line-strong);
 }
 
 .moderation-inline-note strong {
@@ -2050,7 +2119,7 @@ th {
   justify-content: space-between;
   gap: var(--space-5);
   padding: var(--space-4-5) var(--space-5);
-  border: 1px solid var(--color-custom-d8e2ee);
+  border: 1px solid var(--line);
   border-radius: var(--radius-lg);
   background:
     linear-gradient(115deg, rgba(240, 249, 255, 0.94), rgba(248, 250, 252, 0.98) 58%),
@@ -2080,7 +2149,7 @@ th {
   gap: var(--space-0-5);
   min-width: min(100%, 320px);
   padding: var(--space-2-5) var(--space-3);
-  border: 1px solid var(--color-custom-cbdbe8);
+  border: 1px solid var(--line-strong);
   border-radius: var(--radius);
   background: rgba(255, 255, 255, 0.82);
   text-align: right;
@@ -2686,9 +2755,9 @@ th {
   gap: var(--space-3);
   min-width: 0;
   padding: var(--space-3) var(--space-3-5);
-  border: 1px dashed var(--color-slate-300);
+  border: 1px dashed var(--line-strong);
   border-radius: var(--radius);
-  background: var(--color-slate-50);
+  background: var(--panel-alt);
   color: var(--text-secondary);
 }
 
@@ -2883,9 +2952,9 @@ th {
   max-width: 720px;
   margin: 0 auto;
   padding: var(--space-3);
-  border: 1px dashed var(--color-slate-300);
+  border: 1px dashed var(--line-strong);
   border-radius: 8px;
-  background: var(--color-slate-50);
+  background: var(--panel-alt);
   color: var(--text-secondary);
   text-align: left;
 }
@@ -3197,7 +3266,7 @@ th {
   padding: var(--space-4);
   border: 1px solid var(--color-blue-100);
   border-radius: var(--radius);
-  background: var(--color-custom-f8fbff);
+  background: var(--panel);
   min-width: 0;
 }
 
@@ -3623,14 +3692,14 @@ th {
 }
 
 .memory-item-card:hover {
-  border-color: var(--color-slate-300);
+  border-color: var(--line-strong);
   box-shadow: var(--shadow-sm);
 }
 
 .memory-item-card.is-active {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-light);
-  background: var(--color-custom-f8faff);
+  background: var(--panel);
 }
 
 .memory-item-card-head {
@@ -3676,7 +3745,7 @@ th {
   padding: var(--space-3);
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: var(--color-slate-50);
+  background: var(--panel-alt);
 }
 
 .memory-acceptance-detail-head {
@@ -3771,7 +3840,7 @@ th {
   padding: var(--space-2-5);
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
-  background: var(--color-slate-50);
+  background: var(--panel-alt);
   font-size: var(--font-size-sm);
 }
 
@@ -4023,8 +4092,8 @@ th {
   margin-bottom: var(--space-3-5);
   padding: var(--space-3) var(--space-3-5);
   border-radius: var(--radius);
-  background: linear-gradient(135deg, var(--color-slate-50) 0%, var(--color-indigo-50) 100%);
-  border: 1px solid var(--color-custom-dbe3ff);
+  background: linear-gradient(135deg, var(--panel) 0%, var(--panel-alt) 100%);
+  border: 1px solid var(--line);
 }
 
 .persona-scope-note strong {
@@ -4065,8 +4134,8 @@ th {
 .persona-artifact-summary div {
   padding: var(--space-3) var(--space-3-5);
   border-radius: var(--radius);
-  border: 1px solid var(--color-custom-dbe7f3);
-  background: linear-gradient(135deg, var(--color-custom-f8fbff) 0%, var(--color-custom-f2f7ff) 100%);
+  border: 1px solid var(--line);
+  background: linear-gradient(135deg, var(--panel) 0%, var(--panel-alt) 100%);
 }
 
 .persona-artifact-summary span {
@@ -4085,7 +4154,7 @@ th {
 }
 
 .persona-page textarea {
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: var(--font-mono);
   line-height: 1.55;
 }
 
@@ -4182,7 +4251,7 @@ th {
   height: 8px;
   flex: 0 0 8px;
   border-radius: 999px;
-  background: var(--color-slate-400);
+  background: var(--text-muted);
 }
 
 .queue-live-dot.active {
@@ -4219,7 +4288,7 @@ th {
 .queue-summary-card.active {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--accent-light);
-  background: var(--color-custom-f8faff);
+  background: var(--panel);
 }
 
 .queue-summary-card-top {
@@ -4272,7 +4341,7 @@ th {
   max-height: 720px;
   overflow-y: auto;
   border-right: 1px solid var(--line);
-  background: var(--color-slate-50);
+  background: var(--panel-alt);
 }
 
 .queue-message-feed-item {
@@ -4348,7 +4417,7 @@ th {
 .queue-message-channel,
 .queue-message-card-meta span {
   border-radius: 999px;
-  background: var(--color-custom-eef2f7);
+  background: var(--panel-alt);
   color: var(--text-secondary);
   font-size: var(--font-size-2xs);
   font-weight: 750;
@@ -4365,8 +4434,8 @@ th {
   overflow: hidden;
   max-width: 130px;
   margin-left: auto;
-  background: var(--color-custom-eaf1ff);
-  color: var(--color-custom-244a8d);
+  background: var(--panel-alt);
+  color: var(--accent-hover);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -4390,7 +4459,7 @@ th {
   align-items: baseline;
   min-width: 0;
   padding-left: var(--space-2);
-  border-left: 2px solid var(--color-slate-300);
+  border-left: 2px solid var(--line-strong);
   color: var(--text-muted);
   font-size: var(--font-size-xs);
   line-height: 1.45;
@@ -4417,7 +4486,7 @@ th {
 .queue-message-card-meta span + span::before {
   content: "·";
   margin-right: var(--space-1-5);
-  color: var(--color-slate-300);
+  color: var(--line-strong);
 }
 
 .queue-message-card-media {
@@ -4580,7 +4649,7 @@ th {
   text-overflow: ellipsis;
   white-space: nowrap;
   border-radius: 4px;
-  background: rgba(15, 23, 42, 0.78);
+  background: rgba(16, 25, 21, 0.78);
   color: var(--color-white);
   font-size: var(--font-size-3xs);
   line-height: 1;
@@ -4610,10 +4679,10 @@ th {
   border-radius: 8px;
   border: 1px solid var(--line);
   background:
-    linear-gradient(45deg, var(--color-slate-50) 25%, transparent 25%),
-    linear-gradient(-45deg, var(--color-slate-50) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, var(--color-slate-50) 75%),
-    linear-gradient(-45deg, transparent 75%, var(--color-slate-50) 75%);
+    linear-gradient(45deg, var(--panel-alt) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--panel-alt) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--panel-alt) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--panel-alt) 75%);
   background-size: 18px 18px;
   background-position: 0 0, 0 9px, 9px -9px, -9px 0;
   padding: var(--space-2-5);
@@ -4624,7 +4693,7 @@ th {
   gap: var(--space-2-5);
   padding: var(--space-3);
   border: 1px solid var(--line-light);
-  border-left: 3px solid var(--color-slate-400);
+  border-left: 3px solid var(--text-muted);
   border-radius: 8px;
   background: var(--panel-alt);
 }
@@ -4687,7 +4756,7 @@ th {
   padding: var(--space-3-5) var(--space-4);
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
-  background: linear-gradient(180deg, var(--color-custom-f8fbff) 0%, var(--color-custom-eef6ff) 100%);
+  background: linear-gradient(180deg, var(--panel) 0%, var(--panel-alt) 100%);
 }
 
 .credits-mode-current span {
@@ -4725,7 +4794,7 @@ th {
   padding: var(--space-3) var(--space-3-5);
   border-radius: var(--radius-lg);
   border: 1px solid var(--line);
-  background: linear-gradient(180deg, var(--color-white) 0%, var(--color-custom-f8fbff) 100%);
+  background: linear-gradient(180deg, var(--color-white) 0%, var(--panel) 100%);
   box-shadow: var(--shadow-sm);
   text-align: left;
   cursor: pointer;
@@ -4733,14 +4802,14 @@ th {
 }
 
 .credits-mode-card:hover {
-  border-color: rgba(59, 130, 246, 0.2);
+  border-color: rgba(13, 148, 136, 0.2);
   transform: translateY(-1px);
 }
 
 .credits-mode-card.active {
-  border-color: rgba(59, 130, 246, 0.34);
-  background: linear-gradient(180deg, var(--color-custom-f8fbff) 0%, var(--color-custom-eef6ff) 100%);
-  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.08);
+  border-color: rgba(13, 148, 136, 0.34);
+  background: linear-gradient(180deg, var(--panel) 0%, var(--panel-alt) 100%);
+  box-shadow: 0 10px 20px rgba(15, 118, 110, 0.08);
 }
 
 .credits-mode-card strong {
@@ -4781,7 +4850,7 @@ th {
   padding: var(--space-4-5);
   border: 1px solid var(--line);
   border-radius: var(--radius-lg);
-  background: linear-gradient(180deg, var(--color-white) 0%, var(--color-custom-f9fbff) 100%);
+  background: linear-gradient(180deg, var(--color-white) 0%, var(--panel) 100%);
   box-shadow: var(--shadow-sm);
 }
 
@@ -4864,7 +4933,7 @@ th {
 
 .credits-adjust-tab:hover {
   color: var(--text);
-  background: rgba(15, 23, 42, 0.04);
+  background: rgba(16, 25, 21, 0.04);
 }
 
 .credits-adjust-tab.active {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -45,7 +45,7 @@ button {
 
 .app-shell {
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr);
+  grid-template-columns: 248px minmax(0, 1fr);
   min-height: 100vh;
 }
 
@@ -120,16 +120,16 @@ button {
 
 .section-kicker::before {
   content: "";
-  width: 14px;
-  height: 2px;
+  width: 3px;
+  height: 11px;
   flex-shrink: 0;
-  background: var(--accent);
-  opacity: 0.85;
+  border-radius: 2px;
+  background: linear-gradient(180deg, var(--color-pine-400), var(--accent));
 }
 
 .sidebar .section-kicker {
   color: rgba(167, 179, 169, 0.62);
-  padding: var(--space-4) var(--space-5) var(--space-1-5);
+  padding: var(--space-4) var(--space-4) 4px;
 }
 
 .sidebar .section-kicker::before {
@@ -150,9 +150,9 @@ button {
   display: flex;
   align-items: center;
   gap: var(--space-2-5);
-  padding: var(--space-2) var(--space-3);
-  border-radius: 6px;
-  font-size: var(--font-size-base);
+  padding: 7px 10px;
+  border-radius: 8px;
+  font-size: var(--font-size-sm);
   font-weight: 500;
   color: var(--sidebar-text);
   transition: background 120ms, color 120ms;
@@ -282,35 +282,46 @@ button {
 /* ── Main Area ── */
 
 .main-area {
-  padding: var(--space-6) var(--space-8) var(--space-10);
-  max-width: 1400px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 0;
+  max-width: none;
 }
 
 .main-routes {
   min-width: 0;
+  flex: 1;
+  width: 100%;
+  max-width: 1480px;
+  padding: var(--space-8) clamp(var(--space-6), 3vw, 40px) var(--space-12);
 }
 
 .global-session-bar {
   position: sticky;
   top: 0;
   z-index: 15;
-  display: grid;
-  grid-template-columns: minmax(260px, 1fr) minmax(520px, 2fr);
-  gap: var(--space-4);
-  align-items: end;
-  margin: 0 0 var(--space-4-5);
-  padding: var(--space-3-5) var(--space-4);
-  border: 1px solid var(--line-strong);
-  border-radius: var(--radius-lg);
-  background: rgba(251, 250, 245, 0.94);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(12px);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2) var(--space-4);
+  margin: 0;
+  padding: 8px clamp(var(--space-6), 3vw, 40px);
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  background: rgba(251, 250, 245, 0.92);
+  box-shadow: none;
+  backdrop-filter: blur(14px);
 }
 
 .global-session-summary {
-  min-width: 0;
-  display: grid;
-  gap: var(--space-1-5);
+  min-width: 180px;
+  flex: 1 1 220px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px 10px;
 }
 
 .global-session-kicker {
@@ -356,18 +367,16 @@ button {
   color: var(--color-orange-700);
 }
 
-.global-session-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2) var(--space-3);
-  color: var(--text-secondary);
-  font-size: var(--font-size-sm);
+.global-session-count {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
 }
 
 .global-session-status {
   margin: 0;
+  width: 100%;
   color: var(--text-secondary);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
 }
 
 .global-session-status.is-error {
@@ -375,10 +384,17 @@ button {
 }
 
 .global-session-controls {
-  display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) auto;
-  gap: var(--space-2-5);
-  align-items: end;
+  display: flex;
+  flex: 1 1 360px;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.global-session-controls .field {
+  flex: 1 1 220px;
+  min-width: 0;
+  gap: 0;
 }
 
 .global-session-actions {
@@ -395,24 +411,52 @@ button {
 /* ── Page Header ── */
 
 .page-header {
-  margin-bottom: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-5);
   padding-bottom: var(--space-4);
   border-bottom: 1px solid var(--line);
 }
 
+.page-header-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.page-header-copy {
+  min-width: 0;
+}
+
+.page-header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+}
+
+.page-header-actions .action-row {
+  margin-top: 0;
+}
+
 .page-header h1 {
   margin: 0;
-  font-size: var(--font-size-3xl);
+  font-size: clamp(1.4rem, 1.8vw, 1.7rem);
   font-weight: 800;
-  letter-spacing: -0.015em;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
   color: var(--text);
 }
 
 .page-description {
-  margin: var(--space-1-5) 0 0;
+  margin: 0;
   max-width: 72ch;
   color: var(--text-secondary);
-  font-size: var(--font-size-base);
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
 }
 
 /* ── Grid ── */
@@ -420,7 +464,7 @@ button {
 .page-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-5);
+  gap: var(--space-6);
 }
 
 .span-2 { grid-column: span 2; min-width: 0; }
@@ -429,11 +473,12 @@ button {
 /* ── Panel ── */
 
 .panel {
-  padding: var(--space-5);
-  border-radius: var(--radius-lg);
+  container-type: inline-size;
+  container-name: panel;
+  padding: var(--space-6);
+  border-radius: 12px;
   border: 1px solid var(--line);
   background: var(--panel);
-  box-shadow: var(--shadow);
   min-width: 0;
 }
 
@@ -525,14 +570,17 @@ button {
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-3);
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-5);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px dashed var(--line);
 }
 
 .panel-header h3,
 .group-behavior-page .panel-header h2 {
   margin: 0;
-  font-size: var(--font-size-md);
-  font-weight: 600;
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  letter-spacing: -0.02em;
   color: var(--text);
 }
 
@@ -546,7 +594,7 @@ button {
   overflow: visible;
   border: 1px solid var(--line);
   border-radius: calc(var(--radius-lg) - 2px);
-  background: linear-gradient(180deg, var(--panel-alt) 0%, var(--color-slate-100) 100%);
+  background: var(--panel-alt);
 }
 
 .group-behavior-tabs > .tabs-list .tabs-trigger {
@@ -556,6 +604,10 @@ button {
   border: 1px solid transparent;
   border-radius: var(--radius);
   color: var(--text-secondary);
+  font-family: var(--font-body);
+  font-size: inherit;
+  letter-spacing: 0;
+  text-transform: none;
   text-align: left;
   transition: border-color 150ms ease, background 150ms ease, box-shadow 150ms ease,
     color 150ms ease, transform 150ms ease;
@@ -642,14 +694,6 @@ button {
 
 .release-controls-panel {
   border-color: var(--line);
-  background: linear-gradient(180deg, var(--panel) 0%, var(--panel-alt) 100%);
-}
-
-.release-control-card {
-  padding: var(--space-4-5);
-  border-color: var(--line);
-  background: rgba(255, 255, 255, 0.86);
-  box-shadow: 0 1px 2px rgba(16, 25, 21, 0.04);
 }
 
 .release-control-card .panel-header {
@@ -660,6 +704,20 @@ button {
 .release-control-fields {
   gap: var(--space-3);
   align-items: end;
+}
+
+.release-control-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.release-control-card {
+  padding: var(--space-4);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel-alt);
+  box-shadow: none;
 }
 
 .group-behavior-page .release-control-actions {
@@ -730,6 +788,10 @@ button {
     grid-template-columns: minmax(0, 1fr);
   }
 
+  .release-control-grid {
+    grid-template-columns: 1fr;
+  }
+
   .group-behavior-page .release-control-actions {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -762,19 +824,23 @@ button {
 }
 
 .field span {
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-2xs);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
 .field input,
 .field textarea,
 .field select {
   width: 100%;
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius);
-  border: 1px solid var(--line);
-  background: var(--bg);
+  min-height: 40px;
+  padding: var(--space-2-5) var(--space-3);
+  border-radius: 8px;
+  border: 1px solid var(--line-strong);
+  background: var(--bg-surface);
   color: var(--text);
   outline: 2px solid transparent;
   outline-offset: 2px;
@@ -825,10 +891,10 @@ button {
 .searchable-select-trigger,
 .searchable-select-input {
   width: 100%;
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius);
-  border: 1px solid var(--line);
-  background: var(--bg);
+  padding: var(--space-2-5) var(--space-3);
+  border-radius: 8px;
+  border: 1px solid var(--line-strong);
+  background: var(--bg-surface);
   color: var(--text);
   outline: 2px solid transparent;
   outline-offset: 2px;
@@ -837,7 +903,7 @@ button {
 }
 
 .searchable-select-trigger {
-  min-height: 38px;
+  min-height: 40px;
   padding-right: var(--space-10);
   text-align: left;
 }
@@ -976,7 +1042,7 @@ button {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
-  margin-top: var(--space-4);
+  margin-top: var(--space-5);
 }
 
 .button {
@@ -984,12 +1050,13 @@ button {
   align-items: center;
   justify-content: center;
   gap: var(--space-1-5);
-  min-height: 36px;
-  padding: 0 var(--space-3-5);
-  border-radius: var(--radius);
+  min-height: 38px;
+  padding: 0 var(--space-4);
+  border-radius: 8px;
   border: 1px solid transparent;
   font-size: var(--font-size-sm);
-  font-weight: 600;
+  font-weight: 650;
+  letter-spacing: 0.01em;
   transition: background 150ms, border-color 150ms, box-shadow 150ms, transform 100ms;
 }
 
@@ -1030,33 +1097,48 @@ button {
 /* ── Status Grid ── */
 
 .status-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-2-5);
-  margin-top: var(--space-4);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  margin-top: var(--space-5);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--line);
 }
 
 .status-tile {
-  padding: var(--space-3-5) var(--space-4);
-  border-radius: var(--radius);
-  border: 1px solid var(--line);
-  background: var(--bg-surface);
+  flex: 1 1 132px;
+  padding: var(--space-4) var(--space-4);
+  border: 0;
+  border-radius: 0;
+  background: var(--panel-alt);
+}
+
+.status-tile:last-child {
+  border-right: 0;
 }
 
 .status-tile span {
   display: block;
-  margin-bottom: var(--space-1);
+  margin-bottom: var(--space-2);
   color: var(--text-muted);
-  font-size: var(--font-size-xs);
-  font-weight: 500;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-2xs);
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.1em;
 }
 
 .status-tile strong {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
   margin: 0;
-  font-size: var(--font-size-lg);
-  font-weight: 700;
+  font-size: var(--font-size-xl);
+  font-weight: 800;
+  letter-spacing: -0.03em;
   color: var(--text);
 }
 
@@ -1226,6 +1308,9 @@ button {
 }
 
 .knowledge-filter-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 7.5rem;
+  gap: var(--space-2);
   margin-bottom: var(--space-2);
 }
 
@@ -1302,7 +1387,28 @@ button {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
+  max-height: 3.5rem;
   margin-top: var(--space-3);
+  overflow: hidden;
+}
+
+.knowledge-list-item .knowledge-chip-row {
+  flex-wrap: nowrap;
+  max-height: 1.75rem;
+  margin-top: var(--space-2);
+}
+
+.knowledge-preview-disclosure {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--line);
+}
+
+.knowledge-preview-disclosure summary {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  cursor: pointer;
 }
 
 .knowledge-preview-card {
@@ -1512,32 +1618,43 @@ button {
 }
 
 .summary-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--space-3-5);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--line);
 }
 
 .summary-card {
+  flex: 1 1 132px;
   padding: var(--space-4) var(--space-5);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--line);
-  background: var(--panel);
-  box-shadow: var(--shadow-sm);
+  border: 0;
+  border-radius: 0;
+  background: var(--panel-alt);
+  box-shadow: none;
+}
+
+.summary-card:last-child {
+  border-right: 0;
 }
 
 .summary-card span {
   display: block;
-  margin-bottom: var(--space-1);
+  margin-bottom: var(--space-2);
   color: var(--text-muted);
+  font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.1em;
 }
 
 .summary-card strong {
   font-size: var(--font-size-3xl);
-  font-weight: 700;
+  font-weight: 800;
+  letter-spacing: -0.04em;
   color: var(--text);
 }
 
@@ -1833,7 +1950,7 @@ table {
 }
 
 th, td {
-  padding: var(--space-2-5) var(--space-2-5);
+  padding: var(--space-3) var(--space-3);
   border-bottom: 1px solid var(--line-light);
   text-align: left;
   vertical-align: middle;
@@ -1841,6 +1958,9 @@ th, td {
 }
 
 th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   color: var(--text-muted);
   font-family: var(--font-mono);
   font-weight: 600;
@@ -1848,6 +1968,7 @@ th {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   border-bottom-color: var(--line-strong);
+  background: var(--panel-alt);
 }
 
 td {
@@ -4272,13 +4393,16 @@ tbody tr.table-row-active:hover {
 
 .queue-summary-list {
   display: grid;
-  gap: var(--space-2-5);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-2);
+  margin-top: var(--space-4);
 }
 
 .queue-summary-card {
   display: grid;
-  gap: var(--space-2);
-  padding: var(--space-3-5) var(--space-4);
+  gap: var(--space-1);
+  min-height: 0;
+  padding: var(--space-2-5) var(--space-3);
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: var(--bg-surface);
@@ -4901,6 +5025,7 @@ tbody tr.table-row-active:hover {
 
 .credits-meta-list {
   display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--space-2-5);
   margin-bottom: var(--space-3-5);
 }
@@ -4975,12 +5100,21 @@ tbody tr.table-row-active:hover {
 
 @media (max-width: 820px) {
   .main-area {
-    padding: var(--space-5) var(--space-4);
+    padding: 0;
   }
 
-  .global-session-bar,
+  .main-routes {
+    padding: var(--space-5) var(--space-4) var(--space-8);
+  }
+
+  .global-session-bar {
+    flex-direction: column;
+    align-items: stretch;
+    padding: var(--space-3) var(--space-4);
+  }
+
   .global-session-controls {
-    grid-template-columns: 1fr;
+    width: 100%;
   }
 
   .global-session-actions .button {
@@ -5092,6 +5226,7 @@ tbody tr.table-row-active:hover {
   .credits-config-layout,
   .credits-member-layout,
   .credits-detail-grid,
+  .credits-meta-list,
   .knowledge-workbench,
   .knowledge-scope-controls {
     grid-template-columns: 1fr;

--- a/frontend/src/styles/components/badge.css
+++ b/frontend/src/styles/components/badge.css
@@ -57,8 +57,8 @@
 .pill-feature,
 .marketplace-badge,
 .agent-tool-badge {
-  --badge-bg: var(--tone-info-bg);
-  --badge-text: var(--tone-info-text);
+  --badge-bg: var(--tone-accent-bg);
+  --badge-text: var(--tone-accent-text);
 }
 
 .ui-badge--muted,

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -17,3 +17,4 @@
 @import "./interaction.css";
 @import "./components/badge.css";
 @import "./utilities.css";
+@import "./layout.css";

--- a/frontend/src/styles/interaction.css
+++ b/frontend/src/styles/interaction.css
@@ -112,8 +112,12 @@ summary:focus-visible {
   background: var(--panel-alt);
 }
 
-.danger-action-dialog {
-  border-top: 4px solid var(--danger);
+.danger-action-dialog .dialog-header {
+  background: radial-gradient(130% 90% at 50% 0%, rgba(220, 38, 38, 0.07), transparent 70%);
+}
+
+.danger-action-dialog .dialog-header h2 {
+  color: var(--color-red-800);
 }
 
 .danger-action-impact {

--- a/frontend/src/styles/interaction.css
+++ b/frontend/src/styles/interaction.css
@@ -223,10 +223,10 @@ summary:focus-visible {
 
 .tabs-list {
   display: flex;
-  gap: var(--space-1);
+  gap: 0;
   overflow-x: auto;
   overflow-y: hidden;
-  padding: var(--space-1);
+  padding: 0;
   border-bottom: 1px solid var(--line);
   scrollbar-width: thin;
 }
@@ -240,33 +240,37 @@ summary:focus-visible {
 
 .tabs-trigger {
   position: relative;
-  min-height: 40px;
-  padding: var(--space-2) var(--space-3-5);
+  min-height: 42px;
+  padding: var(--space-2) var(--space-4);
   border: 0;
-  border-radius: 7px 7px 0 0;
+  border-radius: 0;
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
   font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   white-space: nowrap;
 }
 
 .tabs-trigger:hover:not(:disabled) {
-  background: var(--line-light);
+  background: transparent;
   color: var(--text);
 }
 
 .tabs-trigger[aria-selected="true"] {
-  background: var(--accent-light);
-  color: var(--accent-hover);
+  background: transparent;
+  color: var(--text);
 }
 
 .tabs-trigger[aria-selected="true"]::after {
   position: absolute;
-  right: 10px;
-  bottom: -4px;
-  left: 10px;
-  height: 3px;
-  border-radius: 999px;
+  right: 12px;
+  bottom: -1px;
+  left: 12px;
+  height: 2px;
+  border-radius: 0;
   background: var(--accent);
   content: "";
 }
@@ -405,29 +409,30 @@ summary:focus-visible {
   justify-items: center;
   max-width: 620px;
   margin: 0 auto;
-  padding: clamp(var(--space-6), 6vw, 64px) var(--space-6);
+  padding: clamp(var(--space-8), 6vw, 72px) var(--space-6);
   color: var(--text-secondary);
   text-align: center;
 }
 
 .empty-state-icon {
   display: grid;
-  width: 54px;
-  height: 54px;
-  margin-bottom: var(--space-3-5);
+  width: 48px;
+  height: 48px;
+  margin-bottom: var(--space-4);
   place-items: center;
-  border: 1px solid var(--line-strong);
-  border-radius: 14px;
-  background: linear-gradient(145deg, var(--color-white), var(--panel-alt));
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: var(--accent-light);
   color: var(--accent-hover);
-  font-size: var(--font-size-3xl);
-  box-shadow: var(--shadow-sm);
+  font-size: var(--font-size-xl);
+  box-shadow: none;
 }
 
 .empty-state h2 {
   margin: 0;
   color: var(--text);
-  font-size: var(--font-size-xl);
+  font-size: var(--font-size-2xl);
+  letter-spacing: -0.03em;
 }
 
 .empty-state p {

--- a/frontend/src/styles/interaction.css
+++ b/frontend/src/styles/interaction.css
@@ -38,7 +38,7 @@ summary:focus-visible {
   place-items: center;
   overflow-y: auto;
   padding: clamp(var(--space-4), 4vw, var(--space-12));
-  background: rgba(2, 6, 23, 0.68);
+  background: rgba(10, 14, 11, 0.68);
   backdrop-filter: blur(5px);
 }
 
@@ -46,10 +46,10 @@ summary:focus-visible {
   width: min(620px, 100%);
   max-height: min(760px, calc(100dvh - 32px));
   overflow: auto;
-  border: 1px solid var(--color-slate-300);
+  border: 1px solid var(--line-strong);
   border-radius: 14px;
   background: var(--bg-surface);
-  box-shadow: 0 28px 80px rgba(2, 6, 23, 0.34);
+  box-shadow: 0 28px 80px rgba(10, 14, 11, 0.34);
 }
 
 .dialog-header {
@@ -92,7 +92,7 @@ summary:focus-visible {
 
 .dialog-close:hover,
 .alert-dismiss:hover {
-  border-color: var(--color-slate-400);
+  border-color: var(--color-ink-500);
   color: var(--text);
 }
 
@@ -361,7 +361,7 @@ summary:focus-visible {
 }
 
 .data-table tbody tr:hover {
-  background: var(--color-slate-50);
+  background: var(--panel-alt);
 }
 
 .data-table-cell-action,
@@ -412,9 +412,9 @@ summary:focus-visible {
   height: 54px;
   margin-bottom: var(--space-3-5);
   place-items: center;
-  border: 1px solid var(--color-slate-300);
+  border: 1px solid var(--line-strong);
   border-radius: 14px;
-  background: linear-gradient(145deg, var(--color-white), var(--color-custom-eef2f7));
+  background: linear-gradient(145deg, var(--color-white), var(--panel-alt));
   color: var(--accent-hover);
   font-size: var(--font-size-3xl);
   box-shadow: var(--shadow-sm);

--- a/frontend/src/styles/layout.css
+++ b/frontend/src/styles/layout.css
@@ -1,0 +1,312 @@
+/* Shared page layout: metric strips, ops toolbars, split workspaces. */
+
+.status-grid,
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: stretch;
+  gap: var(--space-2);
+  overflow: visible;
+  border: 0;
+  background: transparent;
+}
+
+.status-tile,
+.summary-card {
+  flex: none;
+  min-width: 0;
+  max-width: none;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+}
+
+.status-tile:last-child,
+.summary-card:last-child {
+  border-right: 1px solid var(--line);
+}
+
+.queue-stats-grid .status-tile {
+  min-width: 0;
+  max-width: none;
+}
+
+.queue-groups-disclosure {
+  margin-top: var(--space-3);
+}
+
+.page-description {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.page-ops-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.page-ops-bar .field {
+  min-width: 140px;
+  flex: 1 1 160px;
+}
+
+.page-ops-bar .action-row {
+  margin-top: 0;
+  margin-left: auto;
+}
+
+.page-ops-bar .page-meta-line {
+  flex: 1 1 220px;
+  align-items: baseline;
+  margin: 0;
+  padding-bottom: 0.45rem;
+}
+
+.commands-lists {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.token-field {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.token-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1-5);
+}
+
+.token-chips span {
+  display: inline-flex;
+  max-width: 100%;
+  min-height: 1.5rem;
+  align-items: center;
+  padding: 0 var(--space-2);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel-alt);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.token-field textarea {
+  min-height: 6.5rem;
+}
+
+.credits-mode-switch {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.credits-mode-switch button {
+  display: grid;
+  gap: var(--space-1);
+  min-height: 0;
+  padding: var(--space-2-5) var(--space-3);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel);
+  text-align: left;
+}
+
+.credits-mode-switch button.is-active,
+.credits-mode-switch button[aria-checked="true"] {
+  border-color: var(--accent);
+  background: var(--panel-alt);
+}
+
+.credits-mode-switch strong {
+  color: var(--text);
+  font-size: var(--font-size-sm);
+}
+
+.credits-mode-switch small {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+}
+
+.workspace-split {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.92fr) minmax(0, 1.08fr);
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.page-hero-metrics {
+  margin-top: var(--space-4);
+}
+
+.group-scope-empty .empty-state {
+  max-width: none;
+  margin: var(--space-2) 0 0;
+  padding: var(--space-8) var(--space-4) var(--space-6);
+}
+
+.panel-output {
+  min-height: 0;
+}
+
+.panel-output-flush {
+  margin-top: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--line);
+}
+
+.panel-output-flush + .panel-output-flush {
+  margin-top: var(--space-2);
+}
+
+.panel > .panel-output-flush:first-child {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
+
+.page-compose textarea {
+  min-height: 8.5rem;
+}
+
+.page-meta-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-4);
+  margin: 0 0 var(--space-4);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.page-meta-line span {
+  display: inline-flex;
+  gap: var(--space-1-5);
+}
+
+.page-meta-line strong {
+  color: var(--text-secondary);
+  font-weight: 650;
+}
+
+.repeater-config-grid {
+  display: grid;
+  grid-template-columns: minmax(168px, 220px) minmax(200px, 280px);
+  gap: var(--space-4);
+  max-width: 36rem;
+}
+
+.toggle-row {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.toggle-row input[type="checkbox"] {
+  width: 1.125rem;
+  height: 1.125rem;
+  min-width: 1.125rem;
+  min-height: 1.125rem;
+  margin: 0;
+  flex: none;
+}
+
+.toggle-row em {
+  font-style: normal;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.member-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.member-filter-row .field {
+  flex: 1 1 220px;
+  max-width: 320px;
+}
+
+.credits-help-disclosure {
+  margin-top: var(--space-2);
+}
+
+.credits-help-disclosure summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: 650;
+}
+
+.credits-help-disclosure .muted-copy {
+  margin-top: var(--space-2);
+}
+
+.command-catalog-cmd,
+.command-catalog-help {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.command-catalog-cmd small,
+.command-catalog-help code {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  overflow-wrap: anywhere;
+}
+
+.persona-style-actions {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--line);
+}
+
+@media (max-width: 1120px) {
+  .status-grid,
+  .summary-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 820px) {
+  .status-grid,
+  .summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .workspace-split {
+    grid-template-columns: 1fr;
+  }
+
+.commands-lists,
+.credits-mode-switch {
+  grid-template-columns: 1fr;
+}
+
+.queue-summary-list {
+  grid-template-columns: 1fr;
+}
+}
+
+@media (max-width: 680px) {
+  .status-grid,
+  .summary-grid,
+  .queue-stats-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/styles/navigation.css
+++ b/frontend/src/styles/navigation.css
@@ -111,12 +111,30 @@
   cursor: pointer;
 }
 
+.overview-check-meta-wrap {
+  margin-top: var(--space-4);
+}
+
+.overview-check-meta-wrap > summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-2xs);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .overview-check-meta {
   display: grid;
-  gap: var(--space-1-5);
-  margin: var(--space-4-5) 0 0;
+  gap: 0;
+  margin: var(--space-2) 0 0;
   padding: 0;
+  overflow: hidden;
   list-style: none;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel-alt);
 }
 
 .overview-check-meta li {
@@ -124,11 +142,16 @@
   grid-template-columns: 92px minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--space-2-5);
-  min-height: 42px;
-  padding: var(--space-1-5) var(--space-2-5);
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  background: var(--panel-alt);
+  min-height: 40px;
+  padding: var(--space-2) var(--space-3);
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  background: transparent;
+}
+
+.overview-check-meta li:last-child {
+  border-bottom: 0;
 }
 
 .overview-check-meta span {
@@ -322,6 +345,10 @@
   .main-area {
     width: 100%;
     max-width: none;
+    padding: 0;
+  }
+
+  .main-routes {
     padding: var(--space-5) clamp(var(--space-4), 3.4vw, var(--space-8)) var(--space-10);
   }
 }

--- a/frontend/src/styles/navigation.css
+++ b/frontend/src/styles/navigation.css
@@ -19,10 +19,10 @@
   left: 12px;
   z-index: 200;
   padding: var(--space-2-5) var(--space-3-5);
-  border: 1px solid var(--color-sky-300);
+  border: 1px solid var(--color-pine-400);
   border-radius: 6px;
-  background: var(--color-custom-0b1422);
-  color: var(--color-slate-50);
+  background: var(--color-ink-sidebar);
+  color: var(--color-sage-100);
   font-weight: 800;
   transform: translateY(-160%);
   transition: transform 120ms ease;
@@ -94,7 +94,7 @@
 
 .overview-degraded-notice li span {
   color: var(--color-orange-700);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: var(--font-mono);
   font-weight: 800;
   text-transform: uppercase;
 }
@@ -150,11 +150,11 @@
   gap: clamp(var(--space-6), 6vw, 90px);
   overflow: hidden;
   padding: clamp(var(--space-8), 7vw, 88px);
-  border: 1px solid var(--color-custom-d7e2ee);
+  border: 1px solid var(--line-strong);
   border-radius: 18px;
   background:
-    linear-gradient(115deg, rgba(15, 23, 42, 0.98) 0 34%, rgba(248, 250, 252, 0.98) 34% 100%),
-    var(--color-slate-50);
+    linear-gradient(115deg, rgba(16, 25, 21, 0.98) 0 34%, rgba(251, 250, 245, 0.98) 34% 100%),
+    var(--panel-alt);
   box-shadow: var(--shadow-md);
 }
 
@@ -165,14 +165,14 @@
   z-index: -1;
   width: 320px;
   height: 320px;
-  border: 1px solid rgba(14, 116, 144, 0.13);
+  border: 1px solid rgba(15, 118, 110, 0.16);
   transform: rotate(24deg);
   content: "";
 }
 
 .not-found-code {
-  color: var(--color-sky-300);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  color: var(--color-pine-300);
+  font-family: var(--font-mono);
   font-size: clamp(4.8rem, 12vw, 9rem);
   font-weight: 900;
   letter-spacing: -0.11em;
@@ -213,10 +213,10 @@
     align-items: center;
     gap: var(--space-3);
     padding: var(--space-2) var(--space-4);
-    border-bottom: 1px solid rgba(148, 163, 184, 0.18);
-    background: rgba(11, 20, 34, 0.97);
-    color: var(--color-custom-e5edf5);
-    box-shadow: 0 8px 22px rgba(15, 23, 42, 0.16);
+    border-bottom: 1px solid rgba(167, 179, 169, 0.18);
+    background: rgba(16, 25, 21, 0.97);
+    color: var(--color-sage-100);
+    box-shadow: 0 8px 22px rgba(16, 25, 21, 0.16);
     backdrop-filter: blur(14px);
   }
 
@@ -226,17 +226,17 @@
     width: 38px;
     height: 38px;
     place-items: center;
-    border: 1px solid rgba(125, 211, 252, 0.22);
+    border: 1px solid rgba(94, 234, 212, 0.22);
     border-radius: 7px;
-    background: rgba(125, 211, 252, 0.07);
-    color: var(--color-blue-100);
+    background: rgba(94, 234, 212, 0.07);
+    color: var(--color-pine-300);
     font-size: var(--font-size-lg);
   }
 
   .mobile-menu-button:hover,
   .sidebar-close-button:hover {
-    border-color: rgba(125, 211, 252, 0.5);
-    background: rgba(125, 211, 252, 0.14);
+    border-color: rgba(94, 234, 212, 0.5);
+    background: rgba(94, 234, 212, 0.14);
   }
 
   .mobile-route-title {
@@ -246,8 +246,8 @@
   }
 
   .mobile-route-title span {
-    color: var(--color-custom-7890a8);
-    font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    color: var(--color-sage-300);
+    font-family: var(--font-mono);
     font-size: var(--font-size-3xs);
     font-weight: 800;
     letter-spacing: 0.08em;
@@ -256,7 +256,7 @@
 
   .mobile-route-title strong {
     overflow: hidden;
-    color: var(--color-slate-50);
+    color: var(--color-sage-100);
     font-size: var(--font-size-base);
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -281,7 +281,7 @@
     flex-wrap: nowrap;
     overflow-y: auto;
     visibility: hidden;
-    box-shadow: 24px 0 60px rgba(2, 6, 23, 0.32);
+    box-shadow: 24px 0 60px rgba(10, 14, 11, 0.32);
     transform: translateX(-104%);
     transition:
       transform 180ms ease,
@@ -315,7 +315,7 @@
     inset: 0;
     z-index: 60;
     border: 0;
-    background: rgba(2, 6, 23, 0.56);
+    background: rgba(10, 14, 11, 0.56);
     backdrop-filter: blur(3px);
   }
 
@@ -334,8 +334,8 @@
     gap: var(--space-10);
     padding: var(--space-8) var(--space-6);
     background:
-      linear-gradient(170deg, rgba(15, 23, 42, 0.98) 0 32%, rgba(248, 250, 252, 0.98) 32% 100%),
-      var(--color-slate-50);
+      linear-gradient(170deg, rgba(16, 25, 21, 0.98) 0 32%, rgba(251, 250, 245, 0.98) 32% 100%),
+      var(--panel-alt);
   }
 
   .not-found-code {

--- a/frontend/src/styles/pages/auth.css
+++ b/frontend/src/styles/pages/auth.css
@@ -4,7 +4,7 @@
   min-height: 100vh;
   display: grid;
   grid-template-columns: minmax(340px, 0.9fr) minmax(500px, 1.1fr);
-  background: var(--color-custom-eef2f5);
+  background: var(--color-paper);
   color: var(--color-gray-900);
 }
 
@@ -17,8 +17,8 @@
   flex-direction: column;
   justify-content: space-between;
   padding: clamp(var(--space-8), 6vw, 80px);
-  background: var(--color-custom-0b1422);
-  color: var(--color-custom-e5edf5);
+  background: var(--color-ink-sidebar);
+  color: var(--color-sage-100);
 }
 
 .login-brand-mark {
@@ -26,9 +26,9 @@
   width: 54px;
   height: 54px;
   place-items: center;
-  border: 1px solid rgba(125, 211, 252, 0.55);
-  color: var(--color-sky-300);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  border: 1px solid rgba(94, 234, 212, 0.55);
+  color: var(--color-pine-300);
+  font-family: var(--font-mono);
   font-size: var(--font-size-base);
   font-weight: 800;
   letter-spacing: 0.13em;
@@ -42,8 +42,8 @@
 
 .login-eyebrow {
   margin: 0 0 var(--space-2-5);
-  color: var(--color-custom-36c9a5);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  color: var(--color-pine-400);
+  font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   font-weight: 800;
   letter-spacing: 0.16em;
@@ -51,7 +51,7 @@
 
 .login-signal-copy h1 {
   margin: 0;
-  color: var(--color-slate-50);
+  color: var(--color-sage-100);
   font-size: clamp(2.5rem, 6vw, 5.4rem);
   line-height: 0.92;
   letter-spacing: -0.065em;
@@ -60,7 +60,7 @@
 .login-signal-copy > p:last-child {
   max-width: 430px;
   margin: var(--space-6) 0 0;
-  color: var(--color-custom-9fb0c3);
+  color: var(--color-sage-300);
   font-size: var(--font-size-lg);
   line-height: 1.75;
 }
@@ -71,7 +71,7 @@
   display: grid;
   gap: 0;
   max-width: 480px;
-  border-top: 1px solid rgba(148, 163, 184, 0.22);
+  border-top: 1px solid rgba(167, 179, 169, 0.22);
 }
 
 .login-system-list > div {
@@ -79,12 +79,12 @@
   grid-template-columns: 80px minmax(0, 1fr);
   gap: var(--space-4-5);
   padding: var(--space-3) 0;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  border-bottom: 1px solid rgba(167, 179, 169, 0.16);
 }
 
 .login-system-list span {
-  color: var(--color-custom-6f8297);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  color: rgba(167, 179, 169, 0.7);
+  font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   text-transform: uppercase;
 }
@@ -92,8 +92,8 @@
 .login-system-list strong {
   min-width: 0;
   overflow: hidden;
-  color: var(--color-custom-dbe7f3);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  color: var(--color-sage-100);
+  font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   font-weight: 600;
   text-overflow: ellipsis;
@@ -107,7 +107,7 @@
   z-index: -1;
   width: 58%;
   aspect-ratio: 1;
-  border: 1px solid rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(45, 212, 191, 0.12);
   transform: rotate(16deg);
 }
 
@@ -115,7 +115,7 @@
 .login-grid-decoration::after {
   position: absolute;
   content: "";
-  border: 1px solid rgba(56, 189, 248, 0.09);
+  border: 1px solid rgba(45, 212, 191, 0.09);
 }
 
 .login-grid-decoration::before {
@@ -131,7 +131,7 @@
   min-height: 100vh;
   place-items: center;
   padding: clamp(var(--space-6), 7vw, 96px);
-  background: var(--color-custom-eef2f5);
+  background: var(--color-paper);
 }
 
 .login-card {
@@ -143,16 +143,16 @@
   align-items: flex-start;
   gap: var(--space-3-5);
   padding-bottom: var(--space-6);
-  border-bottom: 1px solid var(--color-custom-cfd8e3);
+  border-bottom: 1px solid var(--color-paper-line);
 }
 
 .login-status-dot {
   width: 10px;
   height: 10px;
   margin-top: var(--space-1-5);
-  border: 2px solid var(--color-custom-eef2f5);
-  outline: 2px solid var(--color-custom-13a87f);
-  background: var(--color-custom-13a87f);
+  border: 2px solid var(--color-paper);
+  outline: 2px solid var(--color-pine-600);
+  background: var(--color-pine-600);
 }
 
 .login-card-header h2 {
@@ -164,7 +164,7 @@
 
 .login-card-copy {
   margin: var(--space-6) 0 var(--space-6);
-  color: var(--color-custom-5b6878);
+  color: var(--color-ink-600);
   line-height: 1.75;
 }
 
@@ -174,8 +174,8 @@
 }
 
 .login-token-field > span {
-  color: var(--color-slate-700);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  color: var(--color-ink-700);
+  font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   font-weight: 800;
   letter-spacing: 0.08em;
@@ -185,13 +185,13 @@
 .login-token-input {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  border: 1px solid var(--color-custom-b9c6d4);
-  background: var(--color-slate-50);
+  border: 1px solid var(--color-paper-line-strong);
+  background: var(--color-sage-100);
   transition: border-color 140ms, box-shadow 140ms;
 }
 
 .login-token-input:focus-within {
-  border-color: var(--color-teal-700);
+  border-color: var(--color-pine-800);
   box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.12);
 }
 
@@ -200,16 +200,16 @@
   padding: var(--space-3-5) var(--space-4);
   border: 0;
   background: transparent;
-  color: var(--color-slate-900);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  color: var(--color-ink-900);
+  font-family: var(--font-mono);
 }
 
 .login-token-input button {
   padding: 0 var(--space-4);
   border: 0;
-  border-left: 1px solid var(--color-custom-d7dee7);
+  border-left: 1px solid var(--color-paper-line);
   background: transparent;
-  color: var(--color-teal-700);
+  color: var(--color-pine-800);
   font-size: var(--font-size-xs);
   font-weight: 800;
 }
@@ -239,16 +239,16 @@
   justify-content: space-between;
   margin-top: var(--space-5);
   padding: var(--space-3-5) var(--space-4-5);
-  border: 1px solid var(--color-custom-0b1422);
-  background: var(--color-custom-0b1422);
-  color: var(--color-slate-50);
+  border: 1px solid var(--color-ink-sidebar);
+  background: var(--color-ink-sidebar);
+  color: var(--color-sage-100);
   font-weight: 800;
   transition: background 140ms, border-color 140ms, transform 140ms;
 }
 
 .login-submit:hover:not(:disabled) {
-  border-color: var(--color-teal-700);
-  background: var(--color-teal-700);
+  border-color: var(--color-pine-800);
+  background: var(--color-pine-800);
   transform: translateY(-1px);
 }
 
@@ -262,13 +262,13 @@
   align-items: flex-start;
   gap: var(--space-2);
   margin-top: var(--space-4);
-  color: var(--color-custom-7a8796);
+  color: rgba(167, 179, 169, 0.8);
   font-size: var(--font-size-xs);
   line-height: 1.6;
 }
 
 .login-lock-icon {
-  color: var(--color-custom-13a87f);
+  color: var(--color-pine-600);
   font-size: var(--font-size-3xs);
   line-height: 1.8;
 }
@@ -276,8 +276,8 @@
 .login-page-checking {
   grid-template-columns: 1fr;
   place-items: center;
-  background: var(--color-custom-0b1422);
-  color: var(--color-custom-e5edf5);
+  background: var(--color-ink-sidebar);
+  color: var(--color-sage-100);
 }
 
 .login-checking-card {
@@ -290,21 +290,21 @@
 
 .login-checking-card h1 {
   margin: var(--space-1) 0 var(--space-2-5);
-  color: var(--color-slate-50);
+  color: var(--color-sage-100);
   font-size: var(--font-size-3xl);
 }
 
 .login-checking-card > p:last-child {
   margin: 0;
-  color: var(--color-custom-93a4b8);
+  color: var(--color-sage-300);
 }
 
 .login-checking-spinner {
   width: 28px;
   height: 28px;
   margin-bottom: var(--space-6);
-  border: 2px solid rgba(125, 211, 252, 0.2);
-  border-top-color: var(--color-custom-36c9a5);
+  border: 2px solid rgba(94, 234, 212, 0.2);
+  border-top-color: var(--color-pine-400);
   border-radius: 50%;
   animation: login-spin 800ms linear infinite;
 }
@@ -348,8 +348,8 @@
 
 .sidebar-connection div span {
   overflow: hidden;
-  color: var(--color-custom-7f94aa);
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  color: rgba(167, 179, 169, 0.75);
+  font-family: var(--font-mono);
   font-size: var(--font-size-3xs);
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/frontend/src/styles/pages/capabilities.css
+++ b/frontend/src/styles/pages/capabilities.css
@@ -185,15 +185,36 @@
   min-height: 218px;
   padding: var(--space-3-5) var(--space-3) var(--space-3);
   border: 1px solid rgba(167, 179, 169, 0.18);
-  border-top: 3px solid rgba(167, 179, 169, 0.45);
-  border-radius: 8px;
-  background: rgba(16, 25, 21, 0.66);
+  border-radius: 10px;
+  background:
+    radial-gradient(130% 56% at 50% 0%, var(--launch-step-glow, transparent), transparent 64%),
+    rgba(16, 25, 21, 0.66);
 }
 
-.launch-step.is-ready { border-top-color: var(--color-emerald-400); }
-.launch-step.is-action_required { border-top-color: var(--color-amber-300); }
-.launch-step.is-blocked { border-top-color: var(--color-rose-400); }
-.launch-step.is-degraded { border-top-color: var(--color-pine-400); }
+.launch-step.is-ready { --launch-step-glow: rgba(52, 211, 153, 0.12); }
+.launch-step.is-action_required { --launch-step-glow: rgba(252, 211, 77, 0.12); }
+.launch-step.is-blocked { --launch-step-glow: rgba(251, 113, 133, 0.13); }
+.launch-step.is-degraded { --launch-step-glow: rgba(45, 212, 191, 0.12); }
+
+.launch-step.is-ready .launch-state-badge {
+  --badge-text: var(--color-emerald-300);
+  --badge-border: 1px solid rgba(52, 211, 153, 0.4);
+}
+
+.launch-step.is-action_required .launch-state-badge {
+  --badge-text: var(--color-amber-300);
+  --badge-border: 1px solid rgba(252, 211, 77, 0.4);
+}
+
+.launch-step.is-blocked .launch-state-badge {
+  --badge-text: var(--color-rose-300);
+  --badge-border: 1px solid rgba(251, 113, 133, 0.42);
+}
+
+.launch-step.is-degraded .launch-state-badge {
+  --badge-text: var(--color-pine-300);
+  --badge-border: 1px solid rgba(45, 212, 191, 0.4);
+}
 
 .launch-step-index {
   position: absolute;

--- a/frontend/src/styles/pages/capabilities.css
+++ b/frontend/src/styles/pages/capabilities.css
@@ -1,4 +1,4 @@
-/* ── Tenant capability registry / launch sequence ── */
+﻿/* ── Tenant capability registry / launch sequence ── */
 
 .sidebar-capability-state {
   display: flex;
@@ -7,9 +7,9 @@
   min-height: 34px;
   margin: 0 var(--space-2-5) var(--space-1);
   padding: var(--space-1-5) var(--space-2-5);
-  border: 1px solid rgba(148, 163, 184, 0.14);
+  border: 1px solid rgba(167, 179, 169, 0.14);
   border-radius: 7px;
-  background: rgba(15, 23, 42, 0.42);
+  background: rgba(16, 25, 21, 0.42);
   color: rgba(203, 213, 225, 0.78);
   font-size: var(--font-size-xs);
   line-height: 1.35;
@@ -44,26 +44,26 @@
 }
 
 .sidebar-capability-pulse {
-  background: var(--color-slate-400);
-  box-shadow: 0 0 0 0 rgba(148, 163, 184, 0.45);
+  background: var(--color-sage-300);
+  box-shadow: 0 0 0 0 rgba(167, 179, 169, 0.45);
   animation: capability-pulse 1.6s ease-out infinite;
 }
 
 @keyframes capability-pulse {
-  70% { box-shadow: 0 0 0 6px rgba(148, 163, 184, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(148, 163, 184, 0); }
+  70% { box-shadow: 0 0 0 6px rgba(167, 179, 169, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(167, 179, 169, 0); }
 }
 
 .launch-checklist {
   position: relative;
   overflow: hidden;
   padding: var(--space-6);
-  border-color: var(--color-custom-243148);
+  border-color: rgba(94, 234, 212, 0.16);
   background:
-    radial-gradient(circle at 88% 10%, rgba(56, 189, 248, 0.12), transparent 28%),
-    linear-gradient(145deg, var(--color-gray-900) 0%, var(--color-custom-172033) 58%, var(--color-custom-101827) 100%);
-  color: var(--color-custom-e5edf7);
-  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.18);
+    radial-gradient(circle at 88% 10%, rgba(45, 212, 191, 0.13), transparent 28%),
+    linear-gradient(145deg, var(--color-ink-sidebar) 0%, var(--color-ink-sidebar-raised) 58%, var(--color-ink-sidebar) 100%);
+  color: var(--color-sage-100);
+  box-shadow: 0 18px 44px rgba(16, 25, 21, 0.18);
 }
 
 .launch-checklist::before {
@@ -73,8 +73,8 @@
   pointer-events: none;
   opacity: 0.16;
   background-image:
-    linear-gradient(rgba(148, 163, 184, 0.16) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(148, 163, 184, 0.16) 1px, transparent 1px);
+    linear-gradient(rgba(167, 179, 169, 0.14) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(167, 179, 169, 0.14) 1px, transparent 1px);
   background-size: 28px 28px;
   mask-image: linear-gradient(to bottom, black, transparent 72%);
 }
@@ -84,7 +84,7 @@
   z-index: 1;
 }
 
-.launch-checklist .section-kicker { color: var(--color-sky-300); }
+.launch-checklist .section-kicker { color: var(--color-pine-300); }
 
 .launch-checklist-heading {
   display: flex;
@@ -96,7 +96,7 @@
 .launch-checklist-heading h2,
 .launch-checklist-error h2 {
   margin: var(--space-1) 0 var(--space-1-5);
-  color: var(--color-slate-50);
+  color: var(--color-sage-100);
   font-size: clamp(1.35rem, 2vw, 1.9rem);
   letter-spacing: -0.035em;
 }
@@ -105,11 +105,11 @@
 .launch-checklist-error p {
   max-width: 760px;
   margin: 0;
-  color: var(--color-custom-aebdd0);
+  color: var(--color-sage-300);
 }
 
 .launch-checklist-heading code {
-  color: var(--color-sky-100);
+  color: var(--color-sage-100);
   font-size: 0.9em;
 }
 
@@ -117,21 +117,21 @@
   display: grid;
   min-width: 92px;
   padding: var(--space-2-5) var(--space-3);
-  border: 1px solid rgba(125, 211, 252, 0.25);
+  border: 1px solid rgba(94, 234, 212, 0.25);
   border-radius: 10px;
-  background: rgba(15, 23, 42, 0.6);
+  background: rgba(16, 25, 21, 0.6);
   text-align: right;
 }
 
 .launch-readiness span {
-  color: var(--color-slate-50);
+  color: var(--color-sage-100);
   font-size: var(--font-size-2xl);
   font-weight: 800;
   letter-spacing: -0.04em;
 }
 
 .launch-readiness small {
-  color: var(--color-slate-400);
+  color: var(--color-sage-300);
   font-size: var(--font-size-2xs);
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -155,15 +155,15 @@
 .launch-checklist-empty {
   margin-top: var(--space-6);
   padding: var(--space-4-5) var(--space-5);
-  border: 1px dashed rgba(148, 163, 184, 0.42);
+  border: 1px dashed rgba(167, 179, 169, 0.42);
   border-radius: 12px;
-  background: rgba(15, 23, 42, 0.42);
-  color: var(--color-slate-200);
+  background: rgba(16, 25, 21, 0.42);
+  color: var(--color-sage-300);
 }
 
 .launch-checklist-empty p {
   margin: var(--space-1) 0 0;
-  color: var(--color-slate-400);
+  color: var(--color-sage-300);
   font-size: var(--font-size-sm);
   line-height: 1.55;
 }
@@ -176,7 +176,7 @@
   padding: 0 0 var(--space-1);
   overflow-x: visible;
   list-style: none;
-  scrollbar-color: rgba(148, 163, 184, 0.36) transparent;
+  scrollbar-color: rgba(167, 179, 169, 0.36) transparent;
 }
 
 .launch-step {
@@ -184,23 +184,23 @@
   display: flex;
   min-height: 218px;
   padding: var(--space-3-5) var(--space-3) var(--space-3);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  border-top: 3px solid var(--color-slate-500);
+  border: 1px solid rgba(167, 179, 169, 0.18);
+  border-top: 3px solid rgba(167, 179, 169, 0.45);
   border-radius: 8px;
-  background: rgba(15, 23, 42, 0.66);
+  background: rgba(16, 25, 21, 0.66);
 }
 
 .launch-step.is-ready { border-top-color: var(--color-emerald-400); }
 .launch-step.is-action_required { border-top-color: var(--color-amber-300); }
 .launch-step.is-blocked { border-top-color: var(--color-rose-400); }
-.launch-step.is-degraded { border-top-color: var(--color-sky-400); }
+.launch-step.is-degraded { border-top-color: var(--color-pine-400); }
 
 .launch-step-index {
   position: absolute;
   top: 10px;
   right: 10px;
-  color: rgba(148, 163, 184, 0.35);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: rgba(167, 179, 169, 0.35);
+  font-family: var(--font-mono);
   font-size: var(--font-size-xl);
   font-weight: 800;
 }
@@ -219,11 +219,11 @@
   padding-right: var(--space-6);
 }
 
-.launch-step-heading strong { color: var(--color-slate-100); font-size: var(--font-size-base); }
+.launch-step-heading strong { color: var(--color-sage-100); font-size: var(--font-size-base); }
 
 .launch-step p {
   margin: var(--space-2-5) 0;
-  color: var(--color-slate-400);
+  color: var(--color-sage-300);
   font-size: var(--font-size-xs);
   line-height: 1.55;
 }
@@ -265,10 +265,10 @@
   gap: var(--space-1);
   min-height: 30px;
   padding: var(--space-1) var(--space-2);
-  border: 1px solid rgba(125, 211, 252, 0.28);
+  border: 1px solid rgba(94, 234, 212, 0.28);
   border-radius: 6px;
   background: rgba(14, 116, 144, 0.14);
-  color: var(--color-sky-200);
+  color: var(--color-pine-300);
   font-size: var(--font-size-2xs);
   font-weight: 700;
   text-align: center;
@@ -278,7 +278,7 @@ button.launch-action { cursor: pointer; }
 
 .launch-action:hover,
 .launch-action:focus-visible {
-  border-color: rgba(125, 211, 252, 0.66);
+  border-color: rgba(94, 234, 212, 0.66);
   background: rgba(14, 116, 144, 0.28);
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
@@ -299,15 +299,15 @@ button.launch-action { cursor: pointer; }
   gap: var(--space-4);
   margin-top: var(--space-4);
   padding-top: var(--space-3);
-  border-top: 1px solid rgba(148, 163, 184, 0.14);
-  color: var(--color-slate-400);
+  border-top: 1px solid rgba(167, 179, 169, 0.14);
+  color: var(--color-sage-300);
   font-size: var(--font-size-xs);
 }
 
 .launch-checklist-footer button {
   border: 0;
   background: none;
-  color: var(--color-slate-300);
+  color: var(--color-sage-300);
   font-size: var(--font-size-xs);
   font-weight: 700;
   text-decoration: underline;
@@ -320,8 +320,8 @@ button.launch-action { cursor: pointer; }
   justify-content: space-between;
   gap: var(--space-5);
   padding: var(--space-3-5) var(--space-4-5);
-  border-color: var(--color-slate-300);
-  background: linear-gradient(90deg, var(--color-slate-50), var(--color-custom-eef6fb));
+  border-color: var(--color-sage-300);
+  background: linear-gradient(90deg, var(--color-sage-100), var(--color-paper-dim));
 }
 
 .launch-checklist-collapsed > div {
@@ -347,7 +347,7 @@ button.launch-action { cursor: pointer; }
   width: 48px;
   height: 48px;
   flex: 0 0 48px;
-  border: 1px solid rgba(125, 211, 252, 0.34);
+  border: 1px solid rgba(94, 234, 212, 0.34);
   border-radius: 50%;
 }
 
@@ -359,8 +359,8 @@ button.launch-action { cursor: pointer; }
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--color-sky-300);
-  box-shadow: 0 0 12px rgba(125, 211, 252, 0.8);
+  background: var(--color-pine-300);
+  box-shadow: 0 0 12px rgba(94, 234, 212, 0.8);
   transform-origin: 3px 21px;
   animation: launch-orbit 1.7s linear infinite;
 }
@@ -377,7 +377,7 @@ button.launch-action { cursor: pointer; }
 .launch-loading-lines span {
   height: 96px;
   border-radius: 7px;
-  background: linear-gradient(100deg, rgba(148, 163, 184, 0.08), rgba(148, 163, 184, 0.2), rgba(148, 163, 184, 0.08));
+  background: linear-gradient(100deg, rgba(167, 179, 169, 0.08), rgba(167, 179, 169, 0.2), rgba(167, 179, 169, 0.08));
   background-size: 180% 100%;
   animation: launch-shimmer 1.8s ease-in-out infinite;
 }
@@ -437,11 +437,11 @@ button.launch-action { cursor: pointer; }
 
 .capability-diagnostic.is-blocked { box-shadow: inset 3px 0 var(--color-rose-400); }
 .capability-diagnostic.is-action_required { box-shadow: inset 3px 0 var(--color-amber-300); }
-.capability-diagnostic.is-degraded { box-shadow: inset 3px 0 var(--color-sky-400); }
+.capability-diagnostic.is-degraded { box-shadow: inset 3px 0 var(--color-pine-400); }
 
 .capability-diagnostic-source {
   color: var(--text-muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: var(--font-size-2xs);
   text-transform: uppercase;
 }
@@ -493,9 +493,9 @@ button.launch-action { cursor: pointer; }
 }
 
 .capability-actions .launch-action {
-  border-color: var(--color-slate-300);
-  background: var(--color-slate-50);
-  color: var(--color-sky-800);
+  border-color: var(--color-sage-300);
+  background: var(--color-sage-100);
+  color: var(--color-pine-800);
 }
 
 @media (max-width: 1120px) {

--- a/frontend/src/styles/pages/capabilities.css
+++ b/frontend/src/styles/pages/capabilities.css
@@ -305,24 +305,23 @@ button.launch-action { cursor: pointer; }
   outline-offset: 2px;
 }
 
-.launch-action span {
+.admin-chip {
   padding: var(--space-0-5) var(--space-1);
   border-radius: 3px;
-  background: rgba(251, 191, 36, 0.16);
-  color: var(--color-amber-200);
+  background: rgba(233, 229, 216, 0.14);
+  color: var(--color-sage-100);
   font-size: var(--font-size-3xs);
+  font-weight: 700;
 }
 
 .launch-checklist-footer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: var(--space-4);
   margin-top: var(--space-4);
   padding-top: var(--space-3);
   border-top: 1px solid rgba(167, 179, 169, 0.14);
-  color: var(--color-sage-300);
-  font-size: var(--font-size-xs);
 }
 
 .launch-checklist-footer button {
@@ -347,13 +346,10 @@ button.launch-action { cursor: pointer; }
 
 .launch-checklist-collapsed > div {
   display: grid;
-  grid-template-columns: auto 1fr;
-  column-gap: var(--space-3);
   align-items: baseline;
 }
 
-.launch-checklist-collapsed .section-kicker { grid-column: 1 / -1; }
-.launch-checklist-collapsed span { color: var(--text-secondary); font-size: var(--font-size-sm); }
+.launch-checklist-collapsed .section-kicker { margin-bottom: 0; }
 
 .launch-checklist-error {
   display: flex;
@@ -427,17 +423,17 @@ button.launch-action { cursor: pointer; }
 .capability-attention-count {
   padding: var(--space-1) var(--space-2);
   border-radius: 999px;
-  background: var(--color-orange-50);
-  color: var(--color-orange-800);
+  border: 1px solid var(--tone-accent-border);
+  background: var(--tone-accent-bg);
+  color: var(--tone-accent-text);
   font-size: var(--font-size-xs);
   font-weight: 700;
 }
 
-.capability-diagnostics-copy {
-  margin: 0;
-  padding: 0 var(--space-5) var(--space-4);
-  color: var(--text-secondary);
-  font-size: var(--font-size-sm);
+.capability-attention-count.is-clear {
+  border-color: var(--tone-muted-border);
+  background: var(--tone-muted-bg);
+  color: var(--tone-muted-text);
 }
 
 .capability-diagnostic-grid {
@@ -457,7 +453,7 @@ button.launch-action { cursor: pointer; }
 }
 
 .capability-diagnostic.is-blocked { box-shadow: inset 3px 0 var(--color-rose-400); }
-.capability-diagnostic.is-action_required { box-shadow: inset 3px 0 var(--color-amber-300); }
+.capability-diagnostic.is-action_required { box-shadow: inset 3px 0 var(--color-pine-600); }
 .capability-diagnostic.is-degraded { box-shadow: inset 3px 0 var(--color-pine-400); }
 
 .capability-diagnostic-source {
@@ -509,14 +505,13 @@ button.launch-action { cursor: pointer; }
 
 .capability-actions {
   grid-column: 1 / -1;
+  align-items: center;
   justify-content: flex-start;
   margin-top: 0;
 }
 
-.capability-actions .launch-action {
-  border-color: var(--color-sage-300);
-  background: var(--color-sage-100);
-  color: var(--color-pine-800);
+.capability-actions .button {
+  gap: var(--space-1-5);
 }
 
 @media (max-width: 1120px) {

--- a/frontend/src/styles/pages/plugins.css
+++ b/frontend/src/styles/pages/plugins.css
@@ -97,7 +97,7 @@
 }
 
 .plugins-hero .page-header {
-  max-width: 760px;
+  margin-bottom: var(--space-4);
 }
 
 .plugins-hero .page-title {
@@ -105,15 +105,57 @@
 }
 
 .plugins-overview-grid {
-  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
-  gap: var(--space-2-5);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  margin-bottom: var(--space-3);
+}
+
+.plugin-enablement-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1-5);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.plugin-enablement-list li {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+}
+
+.plugin-enablement-list a {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  min-height: 28px;
+  padding: 0 var(--space-2-5);
+  color: inherit;
+  text-decoration: none;
+}
+
+.plugin-enablement-list li[data-enabled="true"] {
+  border-color: rgba(15, 118, 110, 0.28);
+  background: var(--tone-accent-bg);
+  color: var(--tone-accent-text);
+}
+
+.plugin-enablement-list strong {
+  font-size: var(--font-size-2xs);
+  font-weight: 700;
 }
 
 .plugins-overview-grid .status-tile {
-  padding: var(--space-3-5) var(--space-3-5);
-  border-color: rgba(15, 118, 110, 0.14);
-  background: rgba(255, 255, 255, 0.78);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+  padding: var(--space-4);
+  background: rgba(255, 255, 255, 0.55);
+  box-shadow: none;
 }
 
 .plugins-overview-grid .status-tile strong {
@@ -160,6 +202,29 @@
   background: linear-gradient(180deg, var(--panel-alt) 0%, var(--panel-alt) 100%);
   border-style: dashed;
   opacity: 0.86;
+}
+
+.plugins-page .plugin-card.is-selected,
+.marketplace-card.is-selected {
+  border-color: var(--color-pine-600);
+  box-shadow: 0 0 0 1px rgba(15, 118, 110, 0.28);
+}
+
+.plugins-flow-details > summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+.plugins-flow-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.plugins-flow-details > summary.panel-header {
+  margin-bottom: 0;
+}
+
+.plugins-flow-details[open] > summary.panel-header {
+  margin-bottom: var(--space-3);
 }
 
 .plugins-page .plugin-card.is-restart-required {
@@ -499,20 +564,24 @@
 }
 
 .flow-readiness-grid {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: var(--space-2-5);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--line);
 }
 
 .flow-readiness-card {
-  min-height: 104px;
+  min-height: 0;
   display: grid;
-  align-content: center;
+  align-content: start;
   gap: var(--space-1);
-  padding: var(--space-3);
-  border: 1px solid var(--line-light);
-  border-radius: 8px;
-  background: var(--bg-surface);
+  padding: var(--space-2-5) var(--space-3);
+  border: 0;
+  border-radius: 0;
+  background: var(--panel-alt);
   min-width: 0;
 }
 
@@ -949,29 +1018,37 @@
 }
 
 .flow-run-card {
+  display: grid;
+  gap: var(--space-2-5);
   min-height: 0;
+  padding: var(--space-3-5);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--panel);
 }
 
 .flow-run-metrics {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-2);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2) var(--space-3);
 }
 
 .flow-run-metrics span {
-  display: grid;
-  gap: var(--space-0-5);
-  padding: var(--space-2) var(--space-2-5);
-  border: 1px solid var(--line-light);
-  border-radius: 10px;
-  background: rgba(251, 250, 245, 0.88);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35em;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--text-muted);
   font-size: var(--font-size-xs);
 }
 
 .flow-run-metrics strong {
   color: var(--text);
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-base);
   line-height: 1;
 }
 
@@ -1144,8 +1221,7 @@
 }
 
 .plugins-flow-panel .flow-readiness-grid {
-  grid-template-columns: repeat(auto-fit, minmax(128px, 1fr));
-  height: 100%;
+  height: auto;
 }
 
 .plugins-flow-panel .flow-runtime-summary-grid {
@@ -1155,11 +1231,12 @@
 
 .plugins-flow-panel .flow-readiness-card,
 .plugins-flow-panel .flow-runtime-summary {
-  min-height: 118px;
+  min-height: 0;
+  flex: 1 1 128px;
   align-content: start;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.82);
-  box-shadow: var(--shadow-sm);
+  border-radius: 0;
+  background: var(--panel-alt);
+  box-shadow: none;
 }
 
 .plugins-flow-panel .flow-readiness-card.is-enabled,

--- a/frontend/src/styles/pages/plugins.css
+++ b/frontend/src/styles/pages/plugins.css
@@ -89,11 +89,11 @@
 .plugins-hero {
   display: grid;
   gap: var(--space-4);
-  border-color: var(--color-custom-c7d7fe);
+  border-color: var(--line);
   background:
-    radial-gradient(circle at 8% 10%, rgba(37, 99, 235, 0.14), transparent 28%),
-    radial-gradient(circle at 92% 18%, rgba(14, 165, 233, 0.12), transparent 30%),
-    linear-gradient(135deg, var(--color-custom-f8fbff) 0%, var(--color-custom-eef4ff) 55%, var(--color-slate-50) 100%);
+    radial-gradient(circle at 8% 10%, rgba(15, 118, 110, 0.14), transparent 28%),
+    radial-gradient(circle at 92% 18%, rgba(45, 212, 191, 0.12), transparent 30%),
+    linear-gradient(135deg, var(--panel) 0%, var(--panel-alt) 55%, var(--panel-alt) 100%);
 }
 
 .plugins-hero .page-header {
@@ -111,7 +111,7 @@
 
 .plugins-overview-grid .status-tile {
   padding: var(--space-3-5) var(--space-3-5);
-  border-color: rgba(37, 99, 235, 0.14);
+  border-color: rgba(15, 118, 110, 0.14);
   background: rgba(255, 255, 255, 0.78);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
 }
@@ -124,12 +124,12 @@
 .plugins-scope-panel,
 .plugins-flow-panel,
 .plugins-compact-panel {
-  border-color: var(--color-custom-dbe5f4);
+  border-color: var(--line);
 }
 
 .plugins-loaded-panel,
 .plugins-scope-panel {
-  background: linear-gradient(180deg, var(--color-white) 0%, var(--color-custom-f8fbff) 100%);
+  background: linear-gradient(180deg, var(--color-white) 0%, var(--panel) 100%);
 }
 
 .plugins-page .plugin-card-grid {
@@ -143,21 +143,21 @@
   gap: var(--space-3);
   max-height: none;
   overflow: visible;
-  border-color: var(--color-custom-d9e2f0);
-  background: linear-gradient(180deg, var(--color-white) 0%, var(--color-slate-50) 100%);
+  border-color: var(--line);
+  background: linear-gradient(180deg, var(--color-white) 0%, var(--panel-alt) 100%);
   box-shadow: var(--shadow-sm);
   transition: border-color 140ms ease, box-shadow 140ms ease, transform 140ms ease;
 }
 
 .plugins-page .plugin-card:hover,
 .plugins-page .plugin-card:focus-within {
-  border-color: rgba(37, 99, 235, 0.32);
-  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+  border-color: rgba(15, 118, 110, 0.32);
+  box-shadow: 0 16px 36px rgba(16, 25, 21, 0.08);
   transform: translateY(-1px);
 }
 
 .plugins-page .plugin-card.is-disabled {
-  background: linear-gradient(180deg, var(--color-slate-50) 0%, var(--color-slate-100) 100%);
+  background: linear-gradient(180deg, var(--panel-alt) 0%, var(--panel-alt) 100%);
   border-style: dashed;
   opacity: 0.86;
 }
@@ -203,7 +203,7 @@
 
 .plugins-page .plugin-card-copy {
   margin: 0;
-  color: var(--color-slate-600);
+  color: var(--text-secondary);
   line-height: 1.65;
   overflow-wrap: anywhere;
 }
@@ -220,8 +220,8 @@
 
 .plugins-page .plugin-meta-list div {
   padding: var(--space-2) var(--space-2-5);
-  border-color: var(--color-slate-200);
-  background: rgba(248, 250, 252, 0.88);
+  border-color: var(--line);
+  background: rgba(251, 250, 245, 0.88);
 }
 
 .plugins-page .plugin-meta-list dt {
@@ -258,7 +258,7 @@
 }
 
 .plugins-compact-panel {
-  background: linear-gradient(180deg, var(--color-white) 0%, var(--color-slate-50) 100%);
+  background: linear-gradient(180deg, var(--color-white) 0%, var(--panel-alt) 100%);
 }
 
 .plugins-page .route-list {
@@ -269,10 +269,10 @@
 
 .plugins-page .route-list li {
   padding: var(--space-2-5) var(--space-3);
-  border: 1px solid var(--color-slate-200);
+  border: 1px solid var(--line);
   border-radius: 10px;
-  background: rgba(248, 250, 252, 0.86);
-  color: var(--color-slate-700);
+  background: rgba(251, 250, 245, 0.86);
+  color: var(--color-ink-700);
   line-height: 1.5;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
@@ -282,7 +282,7 @@
 }
 
 .plugins-output-panel .panel-output {
-  border-color: var(--color-custom-dbe5f4);
+  border-color: var(--line);
 }
 
 @media (max-width: 820px) {
@@ -336,8 +336,8 @@
 }
 
 .flow-runtime-overview.is-active {
-  border-color: var(--color-blue-200);
-  background: var(--color-blue-50);
+  border-color: rgba(15, 118, 110, 0.26);
+  background: rgba(15, 118, 110, 0.07);
 }
 
 .flow-runtime-overview.is-danger {
@@ -484,8 +484,8 @@
 
 .flow-runtime-risk-chip.is-ok,
 .flow-runtime-risk-chip.is-info {
-  border-color: var(--color-blue-200);
-  background: var(--color-blue-50);
+  border-color: rgba(15, 118, 110, 0.26);
+  background: rgba(15, 118, 110, 0.07);
 }
 
 .flow-runtime-risk-chip.is-warning {
@@ -590,7 +590,7 @@
   border: 0;
   padding: 0;
   background: transparent;
-  color: var(--color-blue-600);
+  color: var(--accent);
   cursor: pointer;
   font: inherit;
   text-align: left;
@@ -683,8 +683,8 @@
 
 .flow-runtime-node.is-ok,
 .flow-runtime-summary.is-ok {
-  border-color: var(--color-blue-200);
-  background: var(--color-blue-50);
+  border-color: rgba(15, 118, 110, 0.26);
+  background: rgba(15, 118, 110, 0.07);
 }
 
 .flow-runtime-arrow {
@@ -797,9 +797,9 @@
   display: grid;
   gap: var(--space-4);
   padding: var(--space-4);
-  border: 1px solid var(--color-blue-200);
+  border: 1px solid rgba(15, 118, 110, 0.26);
   border-radius: 8px;
-  background: var(--color-custom-f8fbff);
+  background: var(--panel);
   min-width: 0;
 }
 
@@ -863,7 +863,7 @@
   min-height: 132px;
   min-width: 0;
   padding: var(--space-3);
-  border: 1px solid var(--color-blue-200);
+  border: 1px solid rgba(15, 118, 110, 0.26);
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.88);
 }
@@ -899,7 +899,7 @@
 
 .flow-trace-path-card.is-miss {
   border-color: var(--line);
-  background: rgba(248, 250, 252, 0.88);
+  background: rgba(251, 250, 245, 0.88);
 }
 
 .flow-trace-path-card.is-error {
@@ -908,7 +908,7 @@
 }
 
 .flow-trace-path-arrow {
-  color: var(--color-blue-300);
+  color: var(--color-pine-600);
   font-weight: 800;
 }
 
@@ -925,7 +925,7 @@
   min-width: 0;
   min-height: 0;
   padding: var(--space-3);
-  border: 1px solid var(--color-blue-100);
+  border: 1px solid var(--color-sage-100);
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.78);
 }
@@ -964,7 +964,7 @@
   padding: var(--space-2) var(--space-2-5);
   border: 1px solid var(--line-light);
   border-radius: 10px;
-  background: rgba(248, 250, 252, 0.88);
+  background: rgba(251, 250, 245, 0.88);
   color: var(--text-muted);
   font-size: var(--font-size-xs);
 }
@@ -981,9 +981,9 @@
   justify-content: space-between;
   gap: var(--space-3);
   padding: var(--space-2) var(--space-2-5);
-  border: 1px solid var(--color-blue-100);
+  border: 1px solid var(--color-sage-100);
   border-radius: 10px;
-  background: var(--color-custom-f8fbff);
+  background: var(--panel);
   min-width: 0;
 }
 
@@ -1011,9 +1011,9 @@
   max-height: none;
   overflow: visible;
   background:
-    radial-gradient(circle at 12% 4%, rgba(37, 99, 235, 0.08), transparent 26%),
+    radial-gradient(circle at 12% 4%, rgba(15, 118, 110, 0.08), transparent 26%),
     radial-gradient(circle at 88% 12%, rgba(20, 184, 166, 0.08), transparent 28%),
-    linear-gradient(180deg, var(--color-white) 0%, var(--color-custom-f8fbff) 100%);
+    linear-gradient(180deg, var(--color-white) 0%, var(--panel) 100%);
 }
 
 .plugins-flow-panel::before {
@@ -1021,7 +1021,7 @@
   position: absolute;
   inset: 0 0 auto;
   height: 4px;
-  background: linear-gradient(90deg, var(--color-blue-600), var(--color-teal-500), var(--color-amber-500));
+  background: linear-gradient(90deg, var(--color-pine-700), var(--color-pine-400));
 }
 
 .plugins-flow-panel > * {
@@ -1030,7 +1030,7 @@
 
 .plugins-flow-panel .panel-header {
   padding-bottom: var(--space-3-5);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  border-bottom: 1px solid rgba(110, 117, 103, 0.18);
 }
 
 .plugins-flow-panel .panel-header h3 {
@@ -1066,14 +1066,14 @@
   gap: 0;
   padding: 0;
   border-radius: 16px;
-  border-color: rgba(37, 99, 235, 0.18);
+  border-color: rgba(15, 118, 110, 0.18);
   overflow: hidden;
-  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.07);
+  box-shadow: 0 18px 42px rgba(16, 25, 21, 0.07);
 }
 
 .plugins-flow-panel .flow-runtime-overview > div {
   padding: var(--space-4-5) var(--space-5);
-  border-right: 1px solid rgba(148, 163, 184, 0.18);
+  border-right: 1px solid rgba(110, 117, 103, 0.18);
 }
 
 .plugins-flow-panel .flow-runtime-overview > div:last-child {
@@ -1081,13 +1081,13 @@
 }
 
 .plugins-flow-panel .flow-runtime-overview.is-muted {
-  background: linear-gradient(135deg, var(--color-slate-50) 0%, var(--color-slate-100) 100%);
+  background: linear-gradient(135deg, var(--panel-alt) 0%, var(--panel-alt) 100%);
 }
 
 .plugins-flow-panel .flow-runtime-overview.is-active {
   background:
-    radial-gradient(circle at top right, rgba(59, 130, 246, 0.14), transparent 34%),
-    linear-gradient(135deg, var(--color-blue-50) 0%, var(--color-custom-f8fbff) 100%);
+    radial-gradient(circle at top right, rgba(13, 148, 136, 0.14), transparent 34%),
+    linear-gradient(135deg, rgba(15, 118, 110, 0.07) 0%, var(--panel) 100%);
 }
 
 .plugins-flow-panel .flow-runtime-overview.is-danger {
@@ -1100,7 +1100,7 @@
 .plugins-flow-panel .flow-runtime-overview span,
 .plugins-flow-panel .flow-readiness-card span,
 .plugins-flow-panel .flow-runtime-summary span {
-  color: var(--color-slate-500);
+  color: var(--text-muted);
 }
 
 .plugins-flow-panel .flow-runtime-overview strong {
@@ -1114,7 +1114,7 @@
 
 .plugins-flow-panel .flow-runtime-risk {
   border-radius: 14px;
-  border-color: var(--color-blue-100);
+  border-color: var(--color-sage-100);
   background: rgba(255, 255, 255, 0.78);
   box-shadow: var(--shadow-sm);
 }
@@ -1178,7 +1178,7 @@
 
 .plugins-flow-panel .flow-readiness-card.is-off,
 .plugins-flow-panel .flow-runtime-summary.is-off {
-  background: linear-gradient(180deg, var(--color-slate-50) 0%, var(--color-slate-100) 100%);
+  background: linear-gradient(180deg, var(--panel-alt) 0%, var(--panel-alt) 100%);
 }
 
 .plugins-flow-panel .flow-readiness-card.is-error,
@@ -1199,8 +1199,8 @@
   justify-content: space-between;
   padding: var(--space-3-5) var(--space-4);
   border-radius: 14px;
-  border-color: var(--color-slate-300);
-  background: rgba(248, 250, 252, 0.9);
+  border-color: var(--line-strong);
+  background: rgba(251, 250, 245, 0.9);
 }
 
 .plugins-flow-panel .flow-runtime-filter .mono {
@@ -1209,7 +1209,7 @@
 
 .plugins-flow-panel .flow-runtime-advanced {
   border-radius: 14px;
-  border-color: var(--color-blue-100);
+  border-color: var(--color-sage-100);
   background: rgba(255, 255, 255, 0.74);
 }
 
@@ -1237,7 +1237,7 @@
 
 .plugins-flow-panel .flow-runtime-detail {
   border-radius: 14px;
-  border-color: var(--color-custom-dbe5f4);
+  border-color: var(--line);
   background: rgba(255, 255, 255, 0.78);
   box-shadow: var(--shadow-sm);
 }
@@ -1258,7 +1258,7 @@
 
 .plugins-flow-panel .flow-runtime-handler-table {
   max-height: 280px;
-  border: 1px solid var(--color-slate-200);
+  border: 1px solid var(--line);
   border-radius: 12px;
   background: var(--color-white);
   overflow: auto;
@@ -1273,22 +1273,22 @@
   position: sticky;
   top: 0;
   z-index: 1;
-  background: var(--color-slate-50);
+  background: var(--panel-alt);
 }
 
 .plugins-flow-panel .flow-runtime-handler-table td {
-  color: var(--color-slate-700);
+  color: var(--color-ink-700);
   white-space: normal;
   overflow-wrap: anywhere;
 }
 
 .plugins-flow-panel .flow-trace-aggregate {
   border-radius: 16px;
-  border-color: var(--color-blue-200);
+  border-color: rgba(15, 118, 110, 0.26);
   background:
-    radial-gradient(circle at top left, rgba(59, 130, 246, 0.11), transparent 28%),
-    linear-gradient(180deg, var(--color-custom-f8fbff) 0%, var(--color-white) 100%);
-  box-shadow: 0 18px 42px rgba(37, 99, 235, 0.08);
+    radial-gradient(circle at top left, rgba(13, 148, 136, 0.11), transparent 28%),
+    linear-gradient(180deg, var(--panel) 0%, var(--color-white) 100%);
+  box-shadow: 0 18px 42px rgba(15, 118, 110, 0.08);
 }
 
 .plugins-flow-panel .flow-trace-stat-grid {
@@ -1315,7 +1315,7 @@
 }
 
 .plugins-flow-panel .flow-trace-detail-card {
-  border-color: var(--color-blue-100);
+  border-color: var(--color-sage-100);
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.84);
   box-shadow: var(--shadow-sm);
@@ -1405,7 +1405,7 @@
   align-items: center;
   justify-content: center;
   padding: var(--space-6);
-  background: rgba(15, 23, 42, 0.58);
+  background: rgba(16, 25, 21, 0.58);
   backdrop-filter: blur(8px);
 }
 
@@ -1413,13 +1413,13 @@
   width: min(1120px, 100%);
   max-height: min(760px, calc(100vh - 48px));
   overflow: auto;
-  border: 1px solid rgba(191, 219, 254, 0.9);
+  border: 1px solid rgba(167, 179, 169, 0.9);
   border-radius: 24px;
   background:
-    radial-gradient(circle at 8% 0%, rgba(59, 130, 246, 0.16), transparent 32%),
+    radial-gradient(circle at 8% 0%, rgba(13, 148, 136, 0.16), transparent 32%),
     radial-gradient(circle at 100% 20%, rgba(20, 184, 166, 0.13), transparent 28%),
     var(--color-white);
-  box-shadow: 0 28px 80px rgba(15, 23, 42, 0.32);
+  box-shadow: 0 28px 80px rgba(16, 25, 21, 0.32);
   padding: var(--space-6);
 }
 
@@ -1444,16 +1444,16 @@
   margin: var(--space-4-5) 0;
   padding: var(--space-3-5) var(--space-4);
   border-radius: 16px;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: rgba(248, 250, 252, 0.88);
+  border: 1px solid rgba(110, 117, 103, 0.24);
+  background: rgba(251, 250, 245, 0.88);
 }
 
 .trace-flow-status strong {
-  color: var(--color-slate-900);
+  color: var(--text);
 }
 
 .trace-flow-status span {
-  color: var(--color-slate-500);
+  color: var(--text-muted);
   font-size: var(--font-size-base);
 }
 
@@ -1484,10 +1484,10 @@
   grid-template-rows: auto 1fr auto;
   place-items: center;
   gap: var(--space-1-5);
-  border: 1px solid rgba(96, 165, 250, 0.35);
+  border: 1px solid rgba(45, 212, 191, 0.35);
   border-radius: 18px;
-  background: linear-gradient(180deg, rgba(239, 246, 255, 0.98) 0%, rgba(255, 255, 255, 0.98) 100%);
-  box-shadow: 0 14px 34px rgba(37, 99, 235, 0.1);
+  background: linear-gradient(180deg, rgba(230, 236, 231, 0.98) 0%, rgba(255, 255, 255, 0.98) 100%);
+  box-shadow: 0 14px 34px rgba(15, 118, 110, 0.1);
   padding: var(--space-3) var(--space-2-5);
   text-align: center;
 }
@@ -1496,14 +1496,14 @@
   width: 11px;
   height: 11px;
   border-radius: 999px;
-  background: var(--color-blue-600);
-  box-shadow: 0 0 0 5px rgba(37, 99, 235, 0.12);
+  background: var(--accent);
+  box-shadow: 0 0 0 5px rgba(15, 118, 110, 0.12);
 }
 
 .trace-flow-node-label {
   max-width: 100%;
   overflow: hidden;
-  color: var(--color-slate-700);
+  color: var(--color-ink-700);
   font-size: var(--font-size-sm);
   font-weight: 800;
   line-height: 1.2;
@@ -1512,25 +1512,25 @@
 }
 
 .trace-flow-node strong {
-  color: var(--color-slate-900);
+  color: var(--text);
   font-size: var(--font-size-4xl);
   line-height: 1;
 }
 
 .trace-flow-node small {
-  color: var(--color-slate-500);
+  color: var(--text-muted);
   font-size: var(--font-size-xs);
 }
 
 .trace-flow-node.is-miss {
-  border-color: rgba(148, 163, 184, 0.32);
-  background: linear-gradient(180deg, rgba(248, 250, 252, 0.98) 0%, rgba(255, 255, 255, 0.98) 100%);
+  border-color: rgba(110, 117, 103, 0.32);
+  background: linear-gradient(180deg, rgba(251, 250, 245, 0.98) 0%, rgba(255, 255, 255, 0.98) 100%);
   box-shadow: none;
 }
 
 .trace-flow-node.is-miss .trace-flow-node-dot {
-  background: var(--color-slate-400);
-  box-shadow: 0 0 0 5px rgba(148, 163, 184, 0.13);
+  background: var(--text-muted);
+  box-shadow: 0 0 0 5px rgba(110, 117, 103, 0.13);
 }
 
 .trace-flow-node.is-error {
@@ -1545,7 +1545,7 @@
 }
 
 .trace-flow-arrow {
-  color: var(--color-blue-400);
+  color: var(--color-pine-600);
   font-weight: 900;
   text-align: center;
 }
@@ -1558,8 +1558,8 @@
 }
 
 .trace-flow-detail-item {
-  border: 1px solid rgba(226, 232, 240, 0.9);
-  border-left: 4px solid var(--color-blue-600);
+  border: 1px solid rgba(221, 215, 200, 0.9);
+  border-left: 4px solid var(--accent);
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.78);
   padding: var(--space-3);
@@ -1574,18 +1574,18 @@
 }
 
 .trace-flow-detail-item strong {
-  color: var(--color-slate-900);
+  color: var(--text);
 }
 
 .trace-flow-detail-item span,
 .trace-flow-detail-item small {
-  color: var(--color-slate-500);
+  color: var(--text-muted);
   font-size: var(--font-size-sm);
 }
 
 .trace-flow-detail-item p {
   margin: 0 0 var(--space-1);
-  color: var(--color-slate-800);
+  color: var(--text);
   font-weight: 700;
   line-height: 1.35;
   overflow-wrap: anywhere;
@@ -1598,7 +1598,7 @@
 }
 
 .trace-flow-detail-item.is-miss {
-  border-left-color: var(--color-slate-400);
+  border-left-color: var(--text-muted);
 }
 
 .trace-flow-detail-item.is-error {
@@ -1617,7 +1617,7 @@
 
 .trace-flow-modal-grid section {
   min-width: 0;
-  border: 1px solid rgba(226, 232, 240, 0.9);
+  border: 1px solid rgba(221, 215, 200, 0.9);
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.78);
   padding: var(--space-3-5);
@@ -1631,7 +1631,7 @@
   gap: var(--space-2-5);
   padding: var(--space-3-5);
   border-radius: 14px;
-  background: linear-gradient(180deg, var(--color-white) 0%, var(--color-custom-f8fbff) 100%);
+  background: linear-gradient(180deg, var(--color-white) 0%, var(--panel) 100%);
 }
 
 .plugins-flow-panel .flow-run-card .plugin-card-header span {
@@ -1641,26 +1641,26 @@
 .plugins-flow-panel .flow-runtime-advanced {
   overflow: hidden;
   padding: 0;
-  border: 1px solid rgba(148, 163, 184, 0.34);
+  border: 1px solid rgba(110, 117, 103, 0.34);
   border-radius: 20px;
   background:
-    linear-gradient(135deg, rgba(15, 23, 42, 0.045), transparent 42%),
+    linear-gradient(135deg, rgba(16, 25, 21, 0.045), transparent 42%),
     rgba(255, 255, 255, 0.9);
-  box-shadow: 0 16px 38px rgba(15, 23, 42, 0.06);
+  box-shadow: 0 16px 38px rgba(16, 25, 21, 0.06);
   transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
 }
 
 .plugins-flow-panel .flow-runtime-advanced:hover {
-  border-color: rgba(14, 165, 233, 0.5);
-  box-shadow: 0 18px 44px rgba(15, 23, 42, 0.09);
+  border-color: rgba(45, 212, 191, 0.5);
+  box-shadow: 0 18px 44px rgba(16, 25, 21, 0.09);
   transform: translateY(-1px);
 }
 
 .plugins-flow-panel .flow-runtime-advanced[open] {
-  border-color: rgba(37, 99, 235, 0.34);
+  border-color: rgba(15, 118, 110, 0.34);
   background:
-    radial-gradient(circle at 4% 0%, rgba(14, 165, 233, 0.14), transparent 28%),
-    linear-gradient(180deg, rgba(248, 250, 252, 0.98) 0%, rgba(255, 255, 255, 0.98) 100%);
+    radial-gradient(circle at 4% 0%, rgba(45, 212, 191, 0.14), transparent 28%),
+    linear-gradient(180deg, rgba(251, 250, 245, 0.98) 0%, rgba(255, 255, 255, 0.98) 100%);
 }
 
 .plugins-flow-panel .flow-runtime-advanced > summary {
@@ -1671,33 +1671,33 @@
   min-height: 78px;
   padding: var(--space-4) var(--space-4-5) var(--space-4) var(--space-5);
   border-radius: 19px;
-  border-left: 5px solid rgba(14, 165, 233, 0.72);
-  color: var(--color-slate-900);
+  border-left: 5px solid rgba(45, 212, 191, 0.72);
+  color: var(--text);
   cursor: pointer;
   list-style: none;
   outline: 2px solid transparent;
   outline-offset: 2px;
   background:
-    linear-gradient(90deg, rgba(224, 242, 254, 0.68), rgba(255, 255, 255, 0.74) 48%, rgba(239, 246, 255, 0.74));
+    linear-gradient(90deg, rgba(230, 236, 231, 0.68), rgba(255, 255, 255, 0.74) 48%, rgba(230, 236, 231, 0.74));
   transition: background 0.18s ease, border-color 0.18s ease;
 }
 
 .plugins-flow-panel .flow-runtime-advanced[open] > summary {
-  border-bottom: 1px solid rgba(191, 219, 254, 0.72);
+  border-bottom: 1px solid rgba(167, 179, 169, 0.72);
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
-  border-left-color: rgba(37, 99, 235, 0.86);
+  border-left-color: rgba(15, 118, 110, 0.86);
   background:
-    linear-gradient(90deg, rgba(219, 234, 254, 0.9), rgba(255, 255, 255, 0.86) 52%, rgba(238, 242, 255, 0.92));
+    linear-gradient(90deg, rgba(230, 236, 231, 0.9), rgba(255, 255, 255, 0.86) 52%, rgba(230, 236, 231, 0.92));
 }
 
 .plugins-flow-panel .flow-runtime-advanced > summary:hover {
   background:
-    linear-gradient(90deg, rgba(186, 230, 253, 0.76), rgba(255, 255, 255, 0.82) 48%, rgba(219, 234, 254, 0.84));
+    linear-gradient(90deg, rgba(167, 179, 169, 0.76), rgba(255, 255, 255, 0.82) 48%, rgba(230, 236, 231, 0.84));
 }
 
 .plugins-flow-panel .flow-runtime-advanced > summary:focus-visible {
-  box-shadow: inset 0 0 0 3px rgba(14, 165, 233, 0.32);
+  box-shadow: inset 0 0 0 3px rgba(45, 212, 191, 0.32);
 }
 
 .plugins-flow-panel .flow-runtime-advanced > summary::-webkit-details-marker {
@@ -1711,14 +1711,14 @@
 }
 
 .plugins-flow-panel .flow-runtime-advanced > summary > span:first-child > strong {
-  color: var(--color-slate-900);
+  color: var(--text);
   font-size: var(--font-size-md);
   font-weight: 900;
   letter-spacing: -0.02em;
 }
 
 .plugins-flow-panel .flow-runtime-advanced > summary small {
-  color: var(--color-slate-600);
+  color: var(--text-secondary);
   font-size: var(--font-size-sm);
   font-weight: 650;
   line-height: 1.38;
@@ -1730,17 +1730,17 @@
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-1);
-  border: 1px solid rgba(37, 99, 235, 0.18);
+  border: 1px solid rgba(15, 118, 110, 0.18);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.86);
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 10px 24px rgba(16, 25, 21, 0.08);
 }
 
 .plugins-flow-panel .flow-runtime-summary-action > em {
-  border: 1px solid rgba(37, 99, 235, 0.18);
+  border: 1px solid rgba(15, 118, 110, 0.18);
   border-radius: 999px;
-  background: rgba(239, 246, 255, 0.96);
-  color: var(--color-blue-700);
+  background: rgba(230, 236, 231, 0.96);
+  color: var(--accent-hover);
   font-size: var(--font-size-xs);
   font-style: normal;
   font-weight: 850;
@@ -1754,7 +1754,7 @@
   width: 31px;
   height: 31px;
   border-radius: 999px;
-  background: var(--color-slate-900);
+  background: var(--text);
   box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.18);
 }
 
@@ -1799,8 +1799,8 @@
 
 .plugins-flow-panel .flow-runtime-map,
 .plugins-flow-panel .flow-runtime-detail-drawer {
-  border-color: rgba(148, 163, 184, 0.26);
-  background: rgba(248, 250, 252, 0.86);
+  border-color: rgba(110, 117, 103, 0.26);
+  background: rgba(251, 250, 245, 0.86);
   box-shadow: none;
 }
 
@@ -1811,15 +1811,15 @@
 
 .plugins-flow-panel .flow-runtime-map:hover,
 .plugins-flow-panel .flow-runtime-detail-drawer:hover {
-  border-color: rgba(148, 163, 184, 0.34);
+  border-color: rgba(110, 117, 103, 0.34);
   box-shadow: none;
   transform: none;
 }
 
 .plugins-flow-panel .flow-runtime-map[open],
 .plugins-flow-panel .flow-runtime-detail-drawer[open] {
-  border-color: rgba(148, 163, 184, 0.34);
-  background: rgba(248, 250, 252, 0.92);
+  border-color: rgba(110, 117, 103, 0.34);
+  background: rgba(251, 250, 245, 0.92);
 }
 
 .plugins-flow-panel .flow-runtime-map > summary,
@@ -1828,20 +1828,20 @@
   padding: var(--space-3) var(--space-4);
   border-left: 0;
   background:
-    linear-gradient(90deg, rgba(191, 231, 249, 0.92) 0%, rgba(219, 241, 250, 0.88) 38%, rgba(235, 247, 252, 0.9) 100%);
+    linear-gradient(90deg, rgba(167, 179, 169, 0.92) 0%, rgba(230, 236, 231, 0.88) 38%, rgba(230, 236, 231, 0.9) 100%);
 }
 
 .plugins-flow-panel .flow-runtime-map[open] > summary,
 .plugins-flow-panel .flow-runtime-detail-drawer[open] > summary {
-  border-bottom-color: rgba(186, 230, 253, 0.82);
+  border-bottom-color: rgba(167, 179, 169, 0.82);
   background:
-    linear-gradient(90deg, rgba(186, 230, 253, 0.96) 0%, rgba(219, 234, 254, 0.92) 48%, rgba(235, 247, 252, 0.92) 100%);
+    linear-gradient(90deg, rgba(167, 179, 169, 0.96) 0%, rgba(230, 236, 231, 0.92) 48%, rgba(230, 236, 231, 0.92) 100%);
 }
 
 .plugins-flow-panel .flow-runtime-map > summary:hover,
 .plugins-flow-panel .flow-runtime-detail-drawer > summary:hover {
   background:
-    linear-gradient(90deg, rgba(165, 222, 246, 0.98) 0%, rgba(207, 236, 250, 0.94) 44%, rgba(226, 242, 250, 0.94) 100%);
+    linear-gradient(90deg, rgba(167, 179, 169, 0.98) 0%, rgba(230, 236, 231, 0.94) 44%, rgba(230, 236, 231, 0.94) 100%);
 }
 
 .plugins-flow-panel .flow-runtime-map .flow-runtime-summary-action,
@@ -1859,7 +1859,7 @@
   display: grid;
   gap: var(--space-2-5);
   padding: var(--space-3);
-  border: 1px solid rgba(226, 232, 240, 0.9);
+  border: 1px solid rgba(221, 215, 200, 0.9);
   border-radius: 14px;
   background: var(--color-white);
 }
@@ -1873,13 +1873,13 @@
 
 .plugins-flow-panel .flow-runtime-map-section-header h4 {
   margin: 0;
-  color: var(--color-slate-900);
+  color: var(--text);
   font-size: var(--font-size-base);
   letter-spacing: -0.01em;
 }
 
 .plugins-flow-panel .flow-runtime-map-section-header span {
-  color: var(--color-slate-500);
+  color: var(--text-muted);
   font-size: var(--font-size-xs);
   font-weight: 750;
 }
@@ -1899,7 +1899,7 @@
   position: relative;
   min-height: 0;
   padding: var(--space-2-5) var(--space-3) var(--space-2-5) var(--space-4-5);
-  border-color: rgba(148, 163, 184, 0.24);
+  border-color: rgba(110, 117, 103, 0.24);
   border-radius: 12px;
   background: var(--color-white);
   box-shadow: none;
@@ -1912,14 +1912,14 @@
   inset: 11px auto 11px 9px;
   width: 3px;
   border-radius: 999px;
-  background: var(--color-slate-400);
+  background: var(--text-muted);
 }
 
 .plugins-flow-panel .flow-runtime-map .flow-runtime-node.is-enabled::before,
 .plugins-flow-panel .flow-runtime-map .flow-runtime-node.is-ok::before,
 .plugins-flow-panel .flow-runtime-map .flow-runtime-summary.is-enabled::before,
 .plugins-flow-panel .flow-runtime-map .flow-runtime-summary.is-ok::before {
-  background: var(--color-blue-600);
+  background: var(--accent);
 }
 
 .plugins-flow-panel .flow-runtime-map .flow-runtime-node.is-error::before,
@@ -1933,24 +1933,24 @@
 }
 
 .plugins-flow-panel .flow-runtime-detail-drawer .flow-runtime-detail {
-  border-color: rgba(226, 232, 240, 0.95);
+  border-color: rgba(221, 215, 200, 0.95);
   background: var(--color-white);
   box-shadow: none;
 }
 
 .plugins-flow-panel .flow-runtime-detail-drawer .flow-runtime-handler-table {
-  border-color: rgba(226, 232, 240, 0.95);
+  border-color: rgba(221, 215, 200, 0.95);
   box-shadow: none;
 }
 
 .plugins-flow-panel .flow-trace-aggregate {
-  border: 1px solid rgba(37, 99, 235, 0.22);
+  border: 1px solid rgba(15, 118, 110, 0.22);
   border-radius: 22px;
   background:
-    radial-gradient(circle at 0% 0%, rgba(37, 99, 235, 0.15), transparent 30%),
+    radial-gradient(circle at 0% 0%, rgba(15, 118, 110, 0.15), transparent 30%),
     radial-gradient(circle at 100% 8%, rgba(20, 184, 166, 0.1), transparent 26%),
-    linear-gradient(180deg, var(--color-custom-f8fbff) 0%, var(--color-white) 58%);
-  box-shadow: 0 22px 54px rgba(37, 99, 235, 0.1);
+    linear-gradient(180deg, var(--panel) 0%, var(--color-white) 58%);
+  box-shadow: 0 22px 54px rgba(15, 118, 110, 0.1);
 }
 
 .plugins-flow-panel .flow-trace-path {
@@ -1960,17 +1960,17 @@
 
 .plugins-flow-panel .flow-trace-path-card {
   min-height: 122px;
-  border-color: rgba(37, 99, 235, 0.24);
+  border-color: rgba(15, 118, 110, 0.24);
   background: rgba(255, 255, 255, 0.86);
 }
 
 .plugins-flow-panel .flow-trace-path-card.is-hit {
-  box-shadow: 0 14px 30px rgba(37, 99, 235, 0.09);
+  box-shadow: 0 14px 30px rgba(15, 118, 110, 0.09);
 }
 
 .plugins-flow-panel .flow-trace-path-card.is-miss {
   border-style: dashed;
-  color: var(--color-slate-500);
+  color: var(--text-muted);
 }
 
 .plugins-flow-panel .flow-trace-dossier {
@@ -1984,10 +1984,10 @@
 .plugins-flow-panel .flow-trace-health-card,
 .plugins-flow-panel .flow-trace-lane {
   min-width: 0;
-  border: 1px solid rgba(148, 163, 184, 0.22);
+  border: 1px solid rgba(110, 117, 103, 0.22);
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.82);
-  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.055);
+  box-shadow: 0 14px 32px rgba(16, 25, 21, 0.055);
   padding: var(--space-3-5);
 }
 
@@ -1995,7 +1995,7 @@
 .plugins-flow-panel .flow-trace-runtime-card > div,
 .plugins-flow-panel .flow-trace-health-card > span,
 .plugins-flow-panel .flow-trace-lane-title > span {
-  color: var(--color-slate-500);
+  color: var(--text-muted);
   font-size: var(--font-size-xs);
   font-weight: 850;
   letter-spacing: 0.08em;
@@ -2007,7 +2007,7 @@
 .plugins-flow-panel .flow-trace-health-card h5,
 .plugins-flow-panel .flow-trace-lane-header h5 {
   margin: var(--space-0-5) 0 0;
-  color: var(--color-slate-900);
+  color: var(--text);
   font-size: var(--font-size-lg);
 }
 
@@ -2023,7 +2023,7 @@
   gap: var(--space-2-5);
   align-items: baseline;
   padding-bottom: var(--space-2);
-  border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+  border-bottom: 1px solid rgba(221, 215, 200, 0.8);
 }
 
 .plugins-flow-panel .flow-trace-identity-card dl > div:last-child {
@@ -2032,7 +2032,7 @@
 }
 
 .plugins-flow-panel .flow-trace-identity-card dt {
-  color: var(--color-slate-500);
+  color: var(--text-muted);
   font-size: var(--font-size-xs);
   font-weight: 750;
   text-transform: uppercase;
@@ -2040,7 +2040,7 @@
 
 .plugins-flow-panel .flow-trace-identity-card dd {
   margin: 0;
-  color: var(--color-slate-900);
+  color: var(--text);
   font-size: var(--font-size-sm);
   overflow-wrap: anywhere;
 }
@@ -2056,14 +2056,14 @@
   display: grid;
   gap: var(--space-1);
   padding: var(--space-2-5);
-  border: 1px solid rgba(148, 163, 184, 0.24);
+  border: 1px solid rgba(110, 117, 103, 0.24);
   border-radius: 14px;
-  background: rgba(248, 250, 252, 0.9);
+  background: rgba(251, 250, 245, 0.9);
 }
 
 .plugins-flow-panel .flow-trace-runtime-grid article.is-hit {
-  border-color: rgba(37, 99, 235, 0.25);
-  background: var(--color-blue-50);
+  border-color: rgba(15, 118, 110, 0.25);
+  background: rgba(15, 118, 110, 0.07);
 }
 
 .plugins-flow-panel .flow-trace-runtime-grid article.is-error {
@@ -2073,13 +2073,13 @@
 
 .plugins-flow-panel .flow-trace-runtime-grid article span,
 .plugins-flow-panel .flow-trace-runtime-grid article small {
-  color: var(--color-slate-500);
+  color: var(--text-muted);
   font-size: var(--font-size-xs);
   overflow-wrap: anywhere;
 }
 
 .plugins-flow-panel .flow-trace-runtime-grid article strong {
-  color: var(--color-slate-900);
+  color: var(--text);
   overflow-wrap: anywhere;
 }
 
@@ -2096,7 +2096,7 @@
 
 .plugins-flow-panel .flow-trace-health-card p {
   margin: var(--space-2-5) 0 0;
-  color: var(--color-slate-700);
+  color: var(--color-ink-700);
   font-size: var(--font-size-base);
   line-height: 1.45;
 }
@@ -2158,7 +2158,7 @@
   display: block;
   max-width: 100%;
   margin-top: var(--space-1);
-  color: var(--color-slate-500);
+  color: var(--text-muted);
   font-size: var(--font-size-xs);
   font-weight: 650;
   line-height: 1.35;
@@ -2181,7 +2181,7 @@
   align-items: center;
   justify-content: center;
   border-radius: 10px;
-  background: var(--color-slate-900);
+  background: var(--text);
   color: var(--color-white);
   font-size: var(--font-size-base);
 }
@@ -2193,7 +2193,7 @@
   height: 18px;
   align-items: center;
   justify-content: center;
-  color: var(--color-slate-500);
+  color: var(--text-muted);
   font-size: var(--font-size-2xl);
   font-weight: 900;
   transform: rotate(0deg);
@@ -2219,14 +2219,14 @@
 
 .plugins-flow-panel .flow-trace-overflow-drawer {
   margin-top: var(--space-2-5);
-  border: 1px solid rgba(226, 232, 240, 0.9);
+  border: 1px solid rgba(221, 215, 200, 0.9);
   border-radius: 12px;
-  background: rgba(248, 250, 252, 0.82);
+  background: rgba(251, 250, 245, 0.82);
 }
 
 .plugins-flow-panel .flow-trace-overflow-drawer > summary {
   padding: var(--space-2) var(--space-2-5);
-  color: var(--color-blue-600);
+  color: var(--accent);
   cursor: pointer;
   font-size: var(--font-size-xs);
   font-weight: 800;
@@ -2246,8 +2246,8 @@
   grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--space-1-5) var(--space-2-5);
   padding: var(--space-2) var(--space-2-5);
-  border: 1px solid rgba(226, 232, 240, 0.88);
-  border-left: 3px solid var(--color-blue-600);
+  border: 1px solid rgba(221, 215, 200, 0.88);
+  border-left: 3px solid var(--accent);
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.86);
 }
@@ -2270,20 +2270,20 @@
 }
 
 .plugins-flow-panel .flow-trace-event-main span {
-  color: var(--color-slate-500);
+  color: var(--text-muted);
   font-size: var(--font-size-2xs);
   font-weight: 750;
   overflow-wrap: anywhere;
 }
 
 .plugins-flow-panel .flow-trace-event-main strong {
-  color: var(--color-slate-900);
+  color: var(--text);
   font-size: var(--font-size-sm);
   overflow-wrap: anywhere;
 }
 
 .plugins-flow-panel .flow-trace-event-main small {
-  color: var(--color-slate-700);
+  color: var(--color-ink-700);
   font-size: var(--font-size-xs);
   line-height: 1.3;
   overflow: hidden;
@@ -2308,8 +2308,8 @@
 .plugins-flow-panel .flow-trace-event-chips span,
 .plugins-flow-panel .flow-trace-event-meta span {
   border-radius: 999px;
-  background: rgba(241, 245, 249, 0.95);
-  color: var(--color-slate-600);
+  background: rgba(234, 230, 218, 0.95);
+  color: var(--text-secondary);
   font-size: var(--font-size-3xs);
   font-weight: 750;
   padding: var(--space-0-5) var(--space-1-5);
@@ -2324,10 +2324,10 @@
 }
 
 .plugins-flow-panel .flow-trace-empty {
-  border: 1px dashed rgba(148, 163, 184, 0.42);
+  border: 1px dashed rgba(110, 117, 103, 0.42);
   border-radius: 14px;
-  background: rgba(248, 250, 252, 0.84);
-  color: var(--color-slate-500);
+  background: rgba(251, 250, 245, 0.84);
+  color: var(--text-muted);
   font-size: var(--font-size-sm);
   font-weight: 650;
   line-height: 1.45;
@@ -2335,8 +2335,8 @@
 }
 
 .plugins-flow-panel .flow-trace-raw-drawer {
-  border-color: rgba(148, 163, 184, 0.24);
-  background: rgba(248, 250, 252, 0.78);
+  border-color: rgba(110, 117, 103, 0.24);
+  background: rgba(251, 250, 245, 0.78);
   box-shadow: none;
 }
 
@@ -2407,7 +2407,7 @@
 
   .plugins-flow-panel .flow-runtime-overview > div {
     border-right: 0;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+    border-bottom: 1px solid rgba(110, 117, 103, 0.18);
   }
 
   .plugins-flow-panel .flow-runtime-overview > div:last-child {

--- a/frontend/src/styles/pages/plugins.css
+++ b/frontend/src/styles/pages/plugins.css
@@ -1010,18 +1010,11 @@
   position: relative;
   max-height: none;
   overflow: visible;
+  border-color: var(--line-strong);
   background:
-    radial-gradient(circle at 12% 4%, rgba(15, 118, 110, 0.08), transparent 26%),
-    radial-gradient(circle at 88% 12%, rgba(20, 184, 166, 0.08), transparent 28%),
+    radial-gradient(130% 44% at 50% 0%, rgba(15, 118, 110, 0.07), transparent 62%),
+    radial-gradient(circle at 88% 12%, rgba(20, 184, 166, 0.06), transparent 28%),
     linear-gradient(180deg, var(--color-white) 0%, var(--panel) 100%);
-}
-
-.plugins-flow-panel::before {
-  content: "";
-  position: absolute;
-  inset: 0 0 auto;
-  height: 4px;
-  background: linear-gradient(90deg, var(--color-pine-700), var(--color-pine-400));
 }
 
 .plugins-flow-panel > * {

--- a/frontend/src/styles/pages/relationship-graph.css
+++ b/frontend/src/styles/pages/relationship-graph.css
@@ -2,18 +2,57 @@
 
 .relationship-graph-page {
   display: grid;
-  gap: var(--space-5);
+  gap: var(--space-4);
 }
 
 .relationship-graph-page :is(h1, h2, h3) {
   scroll-margin-top: 128px;
 }
 
+.relationship-disclosure > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  min-height: 44px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.relationship-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.relationship-disclosure > summary h3 {
+  margin: 0;
+}
+
+.relationship-disclosure-hint {
+  flex: none;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+.relationship-disclosure[open] > .relationship-disclosure-hint,
+.relationship-disclosure[open] > summary .relationship-disclosure-hint {
+  font-size: 0;
+}
+
+.relationship-disclosure[open] > summary .relationship-disclosure-hint::before {
+  font-size: var(--font-size-xs);
+  content: "收起";
+}
+
+.relationship-disclosure[open] > summary {
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--line);
+}
+
 .relationship-action-panel {
   display: grid;
   gap: var(--space-2-5);
-  border-color: rgba(15, 118, 110, 0.26);
-  box-shadow: 0 10px 24px rgba(16, 25, 21, 0.06);
 }
 
 .relationship-action-bar {

--- a/frontend/src/styles/pages/relationship-graph.css
+++ b/frontend/src/styles/pages/relationship-graph.css
@@ -12,8 +12,8 @@
 .relationship-action-panel {
   display: grid;
   gap: var(--space-2-5);
-  border-color: var(--color-blue-200);
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+  border-color: rgba(15, 118, 110, 0.26);
+  box-shadow: 0 10px 24px rgba(16, 25, 21, 0.06);
 }
 
 .relationship-action-bar {
@@ -292,8 +292,8 @@
 
 .relationship-date-row:hover,
 .relationship-date-row.is-selected {
-  border-color: var(--color-blue-300);
-  background: var(--color-blue-50);
+  border-color: rgba(15, 118, 110, 0.4);
+  background: rgba(15, 118, 110, 0.07);
 }
 
 .relationship-date-row strong,
@@ -309,9 +309,9 @@
   width: fit-content;
   padding: var(--space-0-5) var(--space-1-5);
   border-radius: var(--radius);
-  border: 1px solid var(--color-slate-200);
-  background: var(--color-slate-50);
-  color: var(--color-slate-500);
+  border: 1px solid var(--line);
+  background: var(--color-paper-bright);
+  color: var(--color-ink-500);
   font-size: var(--font-size-2xs);
   font-weight: 800;
 }
@@ -466,9 +466,9 @@
 
 .relationship-view-tab:hover,
 .relationship-view-tab.is-active {
-  border-color: var(--color-blue-300);
-  background: var(--color-blue-50);
-  color: var(--color-blue-700);
+  border-color: rgba(15, 118, 110, 0.4);
+  background: rgba(15, 118, 110, 0.07);
+  color: var(--color-pine-700);
 }
 
 .relationship-graph-legend {
@@ -493,7 +493,7 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: var(--color-slate-400);
+  background: var(--color-paper-line-strong);
 }
 
 .relationship-side-stack {
@@ -513,9 +513,9 @@
   border: 1px solid var(--line-light);
   border-radius: var(--radius);
   background:
-    linear-gradient(90deg, rgba(148, 163, 184, 0.1) 1px, transparent 1px),
-    linear-gradient(180deg, rgba(148, 163, 184, 0.1) 1px, transparent 1px),
-    var(--color-custom-fbfdff);
+    linear-gradient(90deg, rgba(167, 179, 169, 0.1) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(167, 179, 169, 0.1) 1px, transparent 1px),
+    var(--panel);
   background-size: 32px 32px;
 }
 
@@ -528,7 +528,7 @@
 }
 
 .relationship-lane-labels text {
-  fill: var(--color-slate-400);
+  fill: var(--color-paper-line-strong);
   font-size: var(--font-size-2xs);
   font-weight: 800;
   letter-spacing: 0;
@@ -558,7 +558,7 @@
 }
 
 .relationship-edge-line {
-  stroke: var(--color-slate-500);
+  stroke: var(--color-ink-500);
   stroke-width: 1.5;
   stroke-linecap: round;
   opacity: 0.8;
@@ -569,19 +569,19 @@
 }
 
 .relationship-edge.is-neighbor .relationship-edge-line {
-  stroke: var(--color-slate-600);
+  stroke: var(--color-ink-600);
   stroke-width: 2;
   opacity: 0.82;
 }
 
 .relationship-edge.is-selected .relationship-edge-line {
-  stroke: var(--color-blue-600);
+  stroke: var(--color-pine-600);
   stroke-width: 2.8;
   opacity: 0.96;
 }
 
 .relationship-edge-label {
-  fill: var(--color-blue-700);
+  fill: var(--color-pine-700);
   font-size: var(--font-size-xs);
   font-weight: 800;
   text-anchor: middle;
@@ -598,17 +598,17 @@
 }
 
 .relationship-node circle {
-  fill: var(--color-slate-50);
-  stroke: var(--color-slate-500);
+  fill: var(--color-paper-bright);
+  stroke: var(--color-ink-500);
   stroke-width: 2;
-  filter: drop-shadow(0 2px 4px rgba(15, 23, 42, 0.12));
+  filter: drop-shadow(0 2px 4px rgba(16, 25, 21, 0.12));
 }
 
 .relationship-node.is-person circle,
 .relationship-legend-dot.is-person {
-  fill: var(--color-blue-600);
-  background: var(--color-blue-600);
-  stroke: var(--color-blue-700);
+  fill: var(--color-pine-600);
+  background: var(--color-pine-600);
+  stroke: var(--color-pine-700);
 }
 
 .relationship-node.is-topic circle,
@@ -634,16 +634,16 @@
 
 .relationship-node.is-value circle,
 .relationship-legend-dot.is-value {
-  fill: var(--color-slate-400);
-  background: var(--color-slate-400);
-  stroke: var(--color-slate-500);
+  fill: var(--color-paper-line-strong);
+  background: var(--color-paper-line-strong);
+  stroke: var(--color-ink-500);
 }
 
 .relationship-node.is-other circle,
 .relationship-legend-dot.is-other {
-  fill: var(--color-slate-600);
-  background: var(--color-slate-600);
-  stroke: var(--color-slate-700);
+  fill: var(--color-ink-600);
+  background: var(--color-ink-600);
+  stroke: var(--color-ink-700);
 }
 
 .relationship-node.is-selected circle {
@@ -720,13 +720,13 @@
 .relationship-list-item:hover,
 .relationship-list-item.is-selected,
 .relationship-list-item.is-related {
-  border-color: var(--color-blue-300);
-  background: var(--color-blue-50);
+  border-color: rgba(15, 118, 110, 0.4);
+  background: rgba(15, 118, 110, 0.07);
 }
 
 .relationship-list-item.is-related:not(.is-selected) {
-  border-color: var(--color-blue-200);
-  background: var(--color-custom-f8fbff);
+  border-color: rgba(15, 118, 110, 0.26);
+  background: var(--panel);
 }
 
 .relationship-list-item strong,
@@ -748,7 +748,7 @@
   padding: var(--space-0-5) var(--space-1-5);
   border-radius: var(--radius);
   border: 1px solid var(--line);
-  background: var(--color-slate-50);
+  background: var(--color-paper-bright);
   color: var(--text-secondary);
   font-size: var(--font-size-xs);
   font-weight: 700;
@@ -767,9 +767,9 @@
 }
 
 .relationship-acceptance.is-muted {
-  border-color: var(--color-slate-200);
-  background: var(--color-slate-100);
-  color: var(--color-slate-500);
+  border-color: var(--line);
+  background: var(--panel-alt);
+  color: var(--color-ink-500);
 }
 
 .relationship-detail-list {
@@ -840,7 +840,7 @@
   margin: 0;
   padding: var(--space-2) var(--space-2-5);
   border-radius: var(--radius);
-  background: var(--color-slate-50);
+  background: var(--color-paper-bright);
   color: var(--text-secondary);
   border: 1px solid var(--line-light);
   font-size: var(--font-size-sm);

--- a/frontend/src/styles/palette.css
+++ b/frontend/src/styles/palette.css
@@ -11,13 +11,13 @@
   --color-ink-900: #1d201c;
   --color-ink-700: #3c413a;
   --color-ink-600: #575d52;
-  --color-ink-500: #6e7567;
+  --color-ink-500: #596254;
   --color-ink-sidebar: #101915;
   --color-ink-sidebar-raised: #16211c;
   --color-pine-300: #5eead4;
   --color-pine-400: #2dd4bf;
   --color-pine-600: #0d9488;
-  --color-pine-700: #0f766e;
+  --color-pine-700: #0b655f;
   --color-pine-800: #115e59;
   --color-pine-900: #134e4a;
   --color-sage-300: #a7b3a9;
@@ -28,7 +28,7 @@
   --color-custom-0b1422: #0b1422;
   --color-sky-500: #0ea5e9;
   --color-slate-900: #0f172a;
-  --color-teal-700: #0f766e;
+  --color-teal-700: #0b655f;
   --color-custom-101827: #101827;
   --color-gray-900: #111827;
   --color-teal-800: #115e59;

--- a/frontend/src/styles/palette.css
+++ b/frontend/src/styles/palette.css
@@ -1,5 +1,27 @@
 :root {
   /* Raw palette: component styles must consume these through var(). */
+
+  /* Ink & Pine theme primitives */
+  --color-paper: #f2efe6;
+  --color-paper-bright: #fbfaf5;
+  --color-paper-dim: #eae6da;
+  --color-paper-line: #ddd7c8;
+  --color-paper-line-light: #e9e5d8;
+  --color-paper-line-strong: #c9c2ae;
+  --color-ink-900: #1d201c;
+  --color-ink-700: #3c413a;
+  --color-ink-600: #575d52;
+  --color-ink-500: #6e7567;
+  --color-ink-sidebar: #101915;
+  --color-ink-sidebar-raised: #16211c;
+  --color-pine-300: #5eead4;
+  --color-pine-400: #2dd4bf;
+  --color-pine-600: #0d9488;
+  --color-pine-700: #0f766e;
+  --color-pine-800: #115e59;
+  --color-pine-900: #134e4a;
+  --color-sage-300: #a7b3a9;
+  --color-sage-100: #e6ece7;
   --color-sky-600: #0284c7;
   --color-emerald-700: #047857;
   --color-sky-800: #075985;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,32 +1,36 @@
 :root {
   color-scheme: light;
 
+  /* Ink & Pine: warm paper canvas, ink text, pine accent. */
+
   /* Semantic color tokens */
-  --bg: var(--color-custom-f5f7fa);
-  --bg-surface: var(--color-white);
-  --sidebar-bg: var(--color-slate-900);
-  --sidebar-text: var(--color-slate-300);
-  --sidebar-text-bright: var(--color-slate-100);
-  --sidebar-hover: rgba(255, 255, 255, 0.06);
-  --sidebar-active: rgba(99, 102, 241, 0.15);
-  --sidebar-active-text: var(--color-indigo-400);
-  --sidebar-border: rgba(255, 255, 255, 0.06);
-  --panel: var(--color-white);
-  --panel-alt: var(--color-slate-50);
-  --line: var(--color-slate-200);
-  --line-light: var(--color-slate-100);
-  --text: var(--color-slate-900);
-  --text-secondary: var(--color-slate-600);
-  --text-muted: var(--color-slate-500);
-  --muted: var(--color-slate-500);
-  --accent: var(--color-custom-5b5bd6);
-  --accent-hover: var(--color-indigo-600);
-  --accent-light: rgba(91, 91, 214, 0.08);
+  --bg: var(--color-paper);
+  --bg-surface: var(--color-paper-bright);
+  --sidebar-bg: var(--color-ink-sidebar);
+  --sidebar-text: var(--color-sage-300);
+  --sidebar-text-bright: var(--color-sage-100);
+  --sidebar-hover: rgba(255, 255, 255, 0.05);
+  --sidebar-active: rgba(45, 212, 191, 0.09);
+  --sidebar-active-text: var(--color-pine-300);
+  --sidebar-border: rgba(255, 255, 255, 0.07);
+  --panel: var(--color-paper-bright);
+  --panel-alt: var(--color-paper-dim);
+  --line: var(--color-paper-line);
+  --line-light: var(--color-paper-line-light);
+  --line-strong: var(--color-paper-line-strong);
+  --text: var(--color-ink-900);
+  --text-secondary: var(--color-ink-600);
+  --text-muted: var(--color-ink-500);
+  --muted: var(--color-ink-500);
+  --accent: var(--color-pine-700);
+  --accent-hover: var(--color-pine-800);
+  --accent-bright: var(--color-pine-600);
+  --accent-light: rgba(15, 118, 110, 0.08);
   --success: var(--color-emerald-700);
   --warning: var(--color-amber-700);
   --danger: var(--color-red-700);
-  --focus-ring: var(--color-sky-600);
-  --focus-ring-shadow: rgba(2, 132, 199, 0.2);
+  --focus-ring: var(--color-pine-600);
+  --focus-ring-shadow: rgba(13, 148, 136, 0.22);
 
   /* Reusable status tones */
   --tone-info-bg: var(--color-blue-50);
@@ -41,15 +45,21 @@
   --tone-danger-bg: var(--color-red-50);
   --tone-danger-text: var(--color-red-700);
   --tone-danger-border: var(--color-red-200);
-  --tone-muted-bg: var(--color-slate-100);
-  --tone-muted-text: var(--color-slate-600);
-  --tone-muted-border: var(--color-slate-200);
-  --tone-accent-bg: var(--color-purple-50);
-  --tone-accent-text: var(--color-purple-800);
-  --tone-accent-border: var(--color-purple-200);
-  --tone-inverse-bg: rgba(15, 23, 42, 0.78);
-  --tone-inverse-text: var(--color-slate-100);
-  --tone-inverse-border: rgba(148, 163, 184, 0.2);
+  --tone-muted-bg: var(--color-paper-dim);
+  --tone-muted-text: var(--color-ink-600);
+  --tone-muted-border: var(--color-paper-line);
+  --tone-accent-bg: rgba(15, 118, 110, 0.08);
+  --tone-accent-text: var(--color-pine-800);
+  --tone-accent-border: rgba(15, 118, 110, 0.28);
+  --tone-inverse-bg: rgba(29, 32, 28, 0.82);
+  --tone-inverse-text: var(--color-paper-bright);
+  --tone-inverse-border: rgba(233, 229, 216, 0.22);
+
+  /* Typography */
+  --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
+    "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", sans-serif;
+  --font-mono: "Cascadia Code", "JetBrains Mono", Consolas, "SFMono-Regular",
+    Menlo, "PingFang SC", "Microsoft YaHei", monospace;
 
   /* Spacing scale */
   --space-0: 0;
@@ -82,12 +92,12 @@
   --font-size-4xl: 1.75rem;
 
   /* Shape, elevation, and interaction */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -2px rgba(0, 0, 0, 0.04);
-  --radius-sm: 6px;
-  --radius: 8px;
-  --radius-lg: 12px;
+  --shadow-sm: 0 1px 0 rgba(29, 32, 28, 0.04);
+  --shadow: 0 1px 2px rgba(29, 32, 28, 0.05), 0 1px 0 rgba(29, 32, 28, 0.03);
+  --shadow-md: 0 6px 16px -8px rgba(29, 32, 28, 0.18), 0 2px 4px -2px rgba(29, 32, 28, 0.06);
+  --radius-sm: 4px;
+  --radius: 6px;
+  --radius-lg: 10px;
   --radius-pill: 999px;
   --touch-target: 44px;
 }

--- a/migrations/versions/20260902_0050_speaker_portrait_incremental_cursor.py
+++ b/migrations/versions/20260902_0050_speaker_portrait_incremental_cursor.py
@@ -1,0 +1,90 @@
+"""Make speaker portrait hot updates lossless.
+
+Revision ID: 0050_speaker_portrait_cursor
+Revises: 0049_speaker_portrait_hot_update
+Create Date: 2026-09-02
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0050_speaker_portrait_cursor"
+down_revision = "0049_speaker_portrait_hot_update"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE plugin_speaker_portraits
+            ADD COLUMN IF NOT EXISTS last_distilled_message_at VARCHAR(64) NOT NULL DEFAULT ''
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE plugin_speaker_portrait_jobs
+            ADD COLUMN IF NOT EXISTS claimed_pending_messages INTEGER NOT NULL DEFAULT 0
+        """
+    )
+    op.execute(
+        """
+        UPDATE plugin_speaker_portraits AS p
+        SET last_distilled_message_at = COALESCE(
+            NULLIF(split_part(r.evidence_json::jsonb ->> 'time_span', ' ~ ', 2), ''),
+            ''
+        )
+        FROM plugin_speaker_portrait_revisions AS r
+        WHERE r.id = p.current_revision_id
+          AND p.last_distilled_message_at = ''
+        """
+    )
+    op.execute(
+        """
+        UPDATE plugin_speaker_portraits AS p
+        SET session_id = COALESCE(
+            (
+                SELECT NULLIF(j.external_session_id, '')
+                FROM plugin_speaker_portrait_jobs AS j
+                WHERE j.tenant_id = p.tenant_id
+                  AND j.speaker_id = p.speaker_id
+                  AND j.status = 'completed'
+                  AND j.external_session_id <> ''
+                  AND j.external_session_id NOT LIKE 'cx1:%'
+                ORDER BY j.id DESC
+                LIMIT 1
+            ),
+            p.session_id
+        )
+        WHERE p.session_id LIKE 'cx1:%'
+        """
+    )
+    op.execute(
+        """
+        UPDATE plugin_speaker_portrait_jobs AS j
+        SET portrait_id = p.id
+        FROM plugin_speaker_portraits AS p
+        WHERE j.portrait_id IS NULL
+          AND j.tenant_id = p.tenant_id
+          AND j.speaker_id = p.speaker_id
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_speaker_portrait_job_attempt
+        ON plugin_speaker_portrait_jobs (portrait_id, mode, created_at DESC)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_speaker_portrait_job_attempt")
+    op.execute(
+        "ALTER TABLE plugin_speaker_portrait_jobs "
+        "DROP COLUMN IF EXISTS claimed_pending_messages"
+    )
+    op.execute(
+        "ALTER TABLE plugin_speaker_portraits "
+        "DROP COLUMN IF EXISTS last_distilled_message_at"
+    )

--- a/plugins/persona_extract/store.py
+++ b/plugins/persona_extract/store.py
@@ -1652,6 +1652,19 @@ class PersonaExtractStore:
         )
         return self._hydrate_profile(rows[0]) if rows else None
 
+    async def list_profiles_by_slug(self, tenant_id: str, skill_slug: str) -> list[dict]:
+        """All profiles derived from one skill slug, across sessions."""
+
+        if not skill_slug.strip():
+            return []
+        rows = await _exec(
+            "SELECT * FROM plugin_persona_profiles "
+            "WHERE tenant_id = :tid AND skill_slug = :slug "
+            "ORDER BY updated_at DESC",
+            {"tid": tenant_id, "slug": skill_slug.strip()},
+        )
+        return [self._hydrate_profile(row) for row in rows]
+
     async def upsert_profile(
         self,
         *,

--- a/plugins/repeater/hooks.py
+++ b/plugins/repeater/hooks.py
@@ -8,6 +8,7 @@ system repeats the message once and suppresses the normal capability chain.
 from __future__ import annotations
 
 import re
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
 from app.channel import set_reply_policy_override
@@ -28,6 +29,8 @@ from app.preprocessing.pii import detect_and_mask
 from plugins.repeater.store import RepeaterStore
 
 logger = get_logger(__name__)
+
+ScopeExecutionAllowed = Callable[[str, str], Awaitable[bool]]
 _MENTION_PREFIX_RE = re.compile(r"^\s*(?:@\S+[\s\u2005\u00a0]+)+")
 _NON_TEXT_PLACEHOLDERS = {"[图片]", "[语音]", "[视频]", "[文件]"}
 _URL_RE = re.compile(
@@ -191,6 +194,7 @@ def _repeat_member_reason(ctx: PipelineContext, previous_turn: Turn) -> str:
 class RepeaterHook:
     store: RepeaterStore
     record_trigger_enabled: bool = True
+    scope_execution_allowed: ScopeExecutionAllowed | None = None
     name: str = "repeater.repeat"
     point: HookPoint = HookPoint.BEFORE_ROUTE
     # Run after command hooks, but before wxbot group reply-policy suppression.
@@ -217,6 +221,18 @@ class RepeaterHook:
             return
 
         policy_session_id = _repeater_policy_session_id(ctx)
+        if self.scope_execution_allowed is not None:
+            allowed = await self.scope_execution_allowed(
+                event.tenant_id,
+                policy_session_id,
+            )
+            if allowed is not True:
+                ctx.extras["repeater"] = {
+                    "triggered": False,
+                    "reason": "scope_disabled",
+                    "content": "",
+                }
+                return
         cfg = await self.store.get_config(event.tenant_id, policy_session_id)
         if not cfg.get("enabled"):
             return
@@ -339,6 +355,7 @@ def _record_trigger_effect(
 class RepeaterDetectStep:
     store: RepeaterStore
     effect_handler_enabled: bool = False
+    scope_execution_allowed: ScopeExecutionAllowed | None = None
     kind: str = "plugin.repeater.detect"
     owner: str = "repeater"
     name: str = "Detect group repeater"
@@ -360,6 +377,7 @@ class RepeaterDetectStep:
             await RepeaterHook(
                 self.store,
                 record_trigger_enabled=not trigger_as_effect,
+                scope_execution_allowed=self.scope_execution_allowed,
             ).run(ctx)
         except HookAbort as exc:
             signal = _sync_repeater_signal(ctx)

--- a/plugins/repeater/plugin.py
+++ b/plugins/repeater/plugin.py
@@ -7,6 +7,9 @@ dedupe to avoid repeated spam.
 """
 from __future__ import annotations
 
+import asyncio
+
+from app.common.logging import get_logger
 from app.orchestrator.flow import FlowStepDefinition
 from app.plugin.base import Plugin, PluginContext, PluginMeta
 from plugins.repeater.hooks import (
@@ -17,6 +20,8 @@ from plugins.repeater.hooks import (
 from plugins.repeater.router import build_repeater_router
 from plugins.repeater.store import RepeaterStore
 
+logger = get_logger(__name__)
+
 
 class RepeaterPlugin(Plugin):
     meta = PluginMeta(
@@ -26,10 +31,12 @@ class RepeaterPlugin(Plugin):
     )
 
     def __init__(self) -> None:
+        self._ctx: PluginContext | None = None
         self._store: RepeaterStore | None = None
         self._effect_handler_enabled = False
 
     async def initialize(self, ctx: PluginContext) -> None:
+        self._ctx = ctx
         self._store = RepeaterStore(ctx.settings)
         self._effect_handler_enabled = any(
             bool(getattr(ctx.settings, name, False))
@@ -42,8 +49,38 @@ class RepeaterPlugin(Plugin):
         await self._store.ensure_tables()
 
     async def shutdown(self) -> None:
+        self._ctx = None
         self._store = None
         self._effect_handler_enabled = False
+
+    async def _scope_execution_allowed(
+        self,
+        tenant_id: str,
+        session_id: str = "",
+    ) -> bool:
+        registry = getattr(self._ctx.container, "plugin_registry", None) if self._ctx else None
+        gate = getattr(registry, "scope_execution_allowed", None)
+        if not callable(gate):
+            logger.error(
+                "repeater.scope_execution_gate_missing",
+                tenant_id=tenant_id,
+                session_id=session_id,
+            )
+            return False
+        try:
+            return (
+                await gate(
+                    self.meta.name,
+                    tenant_id=str(tenant_id or "").strip(),
+                    session_id=str(session_id or "").strip(),
+                )
+                is True
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("repeater.scope_execution_gate_error", error=str(exc))
+            return False
 
     def get_api_router(self):
         if self._store is None:
@@ -53,7 +90,12 @@ class RepeaterPlugin(Plugin):
     def get_pipeline_hooks(self):
         if self._store is None:
             return []
-        return [RepeaterHook(self._store)]
+        return [
+            RepeaterHook(
+                self._store,
+                scope_execution_allowed=self._scope_execution_allowed,
+            )
+        ]
 
     def get_flow_steps(self) -> list[FlowStepDefinition]:
         return [
@@ -76,6 +118,7 @@ class RepeaterPlugin(Plugin):
             "plugin.repeater.detect": RepeaterDetectStep(
                 self._store,
                 effect_handler_enabled=self._effect_handler_enabled,
+                scope_execution_allowed=self._scope_execution_allowed,
             )
         }
 

--- a/plugins/speaker_portrait/hooks.py
+++ b/plugins/speaker_portrait/hooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from app.channel.models import configuration_session_id
 from app.common.types import channel_id_value
 from app.orchestrator.flow import StepResult
 from app.orchestrator.pipeline import PipelineContext
@@ -19,6 +20,13 @@ def _speaker_id(ctx: PipelineContext) -> str:
         or ctx.event.user_id
         or ""
     ).strip()
+
+
+def _external_session_id(ctx: PipelineContext) -> str:
+    """Return the SDK-facing conversation id without persisting a cx1 fallback."""
+
+    session_id = configuration_session_id(ctx.event, ctx.session).strip()
+    return "" if session_id.startswith("cx1:") else session_id
 
 
 @dataclass
@@ -85,6 +93,8 @@ class SpeakerPortraitNoteStep:
     async def run(self, ctx: PipelineContext) -> StepResult:
         if bool(ctx.event.metadata.get("is_self_sent")):
             return StepResult(reason="self_sent")
+        if not str(ctx.event.message.content or "").strip():
+            return StepResult(reason="no_text")
         speaker_id = _speaker_id(ctx)
         if not speaker_id:
             return StepResult(reason="no_speaker")
@@ -97,7 +107,7 @@ class SpeakerPortraitNoteStep:
             tenant_id=ctx.event.tenant_id,
             speaker_id=speaker_id,
             speaker_name=str(metadata.get("sender_name") or ""),
-            session_id=str(ctx.event.session_id or ""),
+            session_id=_external_session_id(ctx),
             timestamp=timestamp[:64],
             channel=channel_id_value(ctx.event.channel) or "wechat",
         )

--- a/plugins/speaker_portrait/jobs.py
+++ b/plugins/speaker_portrait/jobs.py
@@ -12,11 +12,14 @@ from app.common.logging import get_logger
 from app.common.wxbot_auth import wxbot_sdk_headers
 from app.egress.safe_http import safe_trusted_service_request
 from plugins.local_agent.complete import complete_chat, resolve_local_backend
+from plugins.persona_extract.store import PersonaExtractStore
 from plugins.speaker_portrait.pipeline import (
     apply_coverage,
     build_portrait_prompt,
+    compile_reply_style,
     merge_portrait,
     parse_portrait_payload,
+    portrait_style_slug,
 )
 from plugins.speaker_portrait.store import SpeakerPortraitStore
 from plugins.speaker_portrait.workspace import (
@@ -100,6 +103,52 @@ async def collect_speaker_messages(store: SpeakerPortraitStore, job: dict[str, A
     if since:
         cleaned = [item for item in cleaned if str(item.get("timestamp") or "") > since]
     return cleaned
+
+
+async def sync_applied_styles(
+    settings: Any,
+    *,
+    tenant_id: str,
+    speaker_id: str,
+    speaker_name: str,
+    portrait: dict[str, Any],
+    persona_store: PersonaExtractStore | None = None,
+) -> int:
+    """Recompile reply styles derived from this portrait after it changes.
+
+    Applied styles live in persona profiles (the runtime injection surface);
+    without this sync a hot update refreshes the portrait JSON but group
+    replies keep using the stale compiled prompt.
+    """
+
+    persona_store = persona_store or PersonaExtractStore(settings)
+    slug = portrait_style_slug(speaker_id)
+    profiles = await persona_store.list_profiles_by_slug(tenant_id, slug)
+    synced = 0
+    for profile in profiles:
+        name = str(
+            profile.get("target_name")
+            or profile.get("profile_name")
+            or speaker_name
+            or speaker_id
+        )
+        prompt = compile_reply_style(portrait, name=name)
+        await persona_store.upsert_profile(
+            tenant_id=tenant_id,
+            session_id=str(profile.get("session_id") or ""),
+            channel=str(profile.get("channel") or "wechat"),
+            source_key=str(profile.get("source_key") or "wxbot"),
+            source_label=str(profile.get("source_label") or name),
+            profile_name=str(profile.get("profile_name") or name),
+            prompt_text=prompt,
+            enabled=bool(profile.get("enabled")),
+            profile_id=int(profile["id"]),
+            target_user_id=str(profile.get("target_user_id") or speaker_id),
+            target_name=name,
+            skill_slug=slug,
+        )
+        synced += 1
+    return synced
 
 
 async def run_portrait_job(store: SpeakerPortraitStore, job: dict[str, Any]) -> dict[str, Any]:
@@ -204,6 +253,27 @@ async def run_portrait_job(store: SpeakerPortraitStore, job: dict[str, Any]) -> 
         last_message_at=str((stats.get("time_span") or "").split(" ~ ")[-1] if stats.get("time_span") else ""),
         mode=mode,
     )
+    if bool(getattr(settings, "speaker_portrait_style_sync_enabled", True)):
+        try:
+            synced = await sync_applied_styles(
+                settings,
+                tenant_id=str(job.get("tenant_id") or ""),
+                speaker_id=str(job.get("speaker_id") or ""),
+                speaker_name=str(job.get("speaker_name") or ""),
+                portrait=portrait,
+            )
+            if synced:
+                logger.info(
+                    "speaker_portrait.style_synced",
+                    job_id=job.get("id"),
+                    profiles=synced,
+                )
+        except Exception:
+            logger.warning(
+                "speaker_portrait.style_sync_failed",
+                job_id=job.get("id"),
+                exc_info=True,
+            )
     try:
         cleanup_workspaces(
             str(getattr(settings, "speaker_portrait_data_dir", "/data/portraits") or "/data/portraits"),

--- a/plugins/speaker_portrait/jobs.py
+++ b/plugins/speaker_portrait/jobs.py
@@ -232,11 +232,25 @@ async def run_portrait_job(store: SpeakerPortraitStore, job: dict[str, Any]) -> 
         portrait,
         lines_total=len(messages),
         coverage_file=coverage_file,
+        previous=previous if isinstance(previous, dict) else None,
+        mode=mode,
     )
     if not use_tools:
+        used = int(stats.get("used_messages") or len(messages))
+        portrait = apply_coverage(
+            {
+                **portrait,
+                "coverage": {"lines_read": used, "complete": True},
+                "confidence_provided": True,
+            },
+            lines_total=used,
+            previous=previous if isinstance(previous, dict) else None,
+            mode=mode,
+        )
+        coverage = portrait.get("coverage") if isinstance(portrait.get("coverage"), dict) else {}
         portrait["coverage"] = {
-            "lines_total": int(stats.get("used_messages") or len(messages)),
-            "lines_read": int(stats.get("used_messages") or len(messages)),
+            "lines_total": int(coverage.get("lines_total") or used),
+            "lines_read": int(coverage.get("lines_total") or used),
             "complete": True,
         }
     if not portrait.get("summary") and not any(portrait.get(key) for key in ("likes", "topics")):
@@ -248,7 +262,7 @@ async def run_portrait_job(store: SpeakerPortraitStore, job: dict[str, Any]) -> 
         speaker_id=str(job.get("speaker_id") or ""),
         speaker_name=str(job.get("speaker_name") or ""),
         tenant_id=str(job.get("tenant_id") or ""),
-        session_id=str(job.get("session_id") or ""),
+        session_id=str(job.get("external_session_id") or job.get("session_id") or ""),
         message_count=int(stats.get("used_messages") or 0),
         last_message_at=str((stats.get("time_span") or "").split(" ~ ")[-1] if stats.get("time_span") else ""),
         mode=mode,

--- a/plugins/speaker_portrait/pipeline.py
+++ b/plugins/speaker_portrait/pipeline.py
@@ -476,6 +476,12 @@ def _style_bullets(items: Any, *, limit: int = 8) -> list[str]:
     return lines
 
 
+def portrait_style_slug(speaker_id: str) -> str:
+    """Stable persona-profile slug for styles derived from this portrait."""
+
+    return f"portrait-{str(speaker_id).replace('_', '-')}"[:128]
+
+
 def compile_reply_style(portrait: dict[str, Any], *, name: str) -> str:
     """Turn a speaker portrait into a first-person COS skill prompt."""
 

--- a/plugins/speaker_portrait/pipeline.py
+++ b/plugins/speaker_portrait/pipeline.py
@@ -396,6 +396,8 @@ def apply_coverage(
     *,
     lines_total: int,
     coverage_file: Any = None,
+    previous: dict[str, Any] | None = None,
+    mode: str = "full",
 ) -> dict[str, Any]:
     reported = portrait.get("coverage") if isinstance(portrait.get("coverage"), dict) else {}
     file_cov: dict[str, Any] = {}
@@ -408,10 +410,24 @@ def apply_coverage(
         except (OSError, TypeError, ValueError, json.JSONDecodeError):
             file_cov = {}
     try:
-        lines_read = int(file_cov.get("lines_read") or reported.get("lines_read") or 0)
+        batch_read = int(file_cov.get("lines_read") or reported.get("lines_read") or 0)
     except (TypeError, ValueError):
-        lines_read = 0
-    total = max(0, int(lines_total or 0))
+        batch_read = 0
+    batch_total = max(0, int(lines_total or 0))
+    prev_total = 0
+    prev_read = 0
+    if str(mode or "").strip().lower() == "incremental" and isinstance(previous, dict):
+        prev_cov = previous.get("coverage") if isinstance(previous.get("coverage"), dict) else {}
+        try:
+            prev_total = max(0, int(prev_cov.get("lines_total") or 0))
+        except (TypeError, ValueError):
+            prev_total = 0
+        try:
+            prev_read = max(0, int(prev_cov.get("lines_read") or 0))
+        except (TypeError, ValueError):
+            prev_read = 0
+    total = prev_total + batch_total
+    lines_read = prev_read + batch_read if batch_read > 0 else prev_read
     complete = total > 0 and lines_read >= int(total * 0.8)
     if lines_read <= 0 and total > 0:
         complete = False

--- a/plugins/speaker_portrait/plugin.py
+++ b/plugins/speaker_portrait/plugin.py
@@ -126,7 +126,6 @@ class SpeakerPortraitPlugin(Plugin):
             ),
         )
         for portrait in due:
-            await self._store.clear_pending(int(portrait["id"]))
             await self._store.create_job(
                 tenant_id=str(portrait.get("tenant_id") or ""),
                 session_id=str(portrait.get("session_id") or ""),
@@ -137,7 +136,9 @@ class SpeakerPortraitPlugin(Plugin):
                 days_limit=14,
                 max_messages=800,
                 mode="incremental",
-                since_timestamp=str(portrait.get("last_message_at") or ""),
+                since_timestamp=str(portrait.get("last_distilled_message_at") or ""),
+                portrait_id=int(portrait["id"]),
+                claimed_pending_messages=int(portrait.get("pending_messages") or 0),
             )
 
     def get_api_router(self):

--- a/plugins/speaker_portrait/router.py
+++ b/plugins/speaker_portrait/router.py
@@ -10,7 +10,7 @@ from pydantic import Field
 from app.admin.auth_router import authenticate_admin_request
 from app.common.request_models import StrictRequestModel
 from plugins.persona_extract.store import PersonaExtractStore
-from plugins.speaker_portrait.pipeline import compile_reply_style
+from plugins.speaker_portrait.pipeline import compile_reply_style, portrait_style_slug
 from plugins.speaker_portrait.store import SpeakerPortraitStore
 
 
@@ -150,7 +150,7 @@ def build_speaker_portrait_router(
             raise HTTPException(404, "portrait_not_found")
         payload = _style_payload(record)
         persona_store = PersonaExtractStore(store.settings)
-        slug = f"portrait-{speaker_id.replace('_', '-')}"[:128]
+        slug = portrait_style_slug(speaker_id)
         profile = await persona_store.upsert_profile(
             tenant_id=body.tenant_id,
             session_id=body.session_id,

--- a/plugins/speaker_portrait/store.py
+++ b/plugins/speaker_portrait/store.py
@@ -66,20 +66,70 @@ class SpeakerPortraitStore:
         max_messages: int = 4000,
         mode: str = "full",
         since_timestamp: str = "",
+        portrait_id: int | None = None,
+        claimed_pending_messages: int | None = None,
     ) -> dict[str, Any]:
         normalized_mode = "incremental" if str(mode or "").strip().lower() == "incremental" else "full"
         async with get_engine().begin() as conn:
+            portrait_result = await conn.execute(
+                text(
+                    f"""
+                    SELECT id, session_id, pending_messages, last_distilled_message_at
+                    FROM {PORTRAIT_TABLE}
+                    WHERE tenant_id = :tenant_id AND channel = 'wechat'
+                      AND source_key = 'wxbot' AND speaker_id = :speaker_id
+                    FOR UPDATE
+                    """
+                ),
+                {"tenant_id": tenant_id, "speaker_id": speaker_id},
+            )
+            portrait = portrait_result.mappings().first()
+            resolved_portrait_id = int(portrait_id) if portrait_id is not None else None
+            if resolved_portrait_id is None and portrait is not None:
+                resolved_portrait_id = int(portrait["id"])
+            resolved_pending = claimed_pending_messages
+            if resolved_pending is None:
+                resolved_pending = int(portrait["pending_messages"] or 0) if portrait is not None else 0
+            resolved_since = str(since_timestamp or "").strip()
+            if normalized_mode == "incremental" and not resolved_since and portrait is not None:
+                resolved_since = str(portrait["last_distilled_message_at"] or "").strip()
+            resolved_external_session_id = str(external_session_id or "").strip()
+            if (
+                (not resolved_external_session_id or resolved_external_session_id.startswith("cx1:"))
+                and portrait is not None
+            ):
+                stored_session_id = str(portrait["session_id"] or "").strip()
+                if stored_session_id and not stored_session_id.startswith("cx1:"):
+                    resolved_external_session_id = stored_session_id
+            if resolved_portrait_id is not None:
+                active_result = await conn.execute(
+                    text(
+                        f"""
+                        SELECT * FROM {JOB_TABLE}
+                        WHERE portrait_id = :portrait_id
+                          AND status IN ('queued', 'running')
+                        ORDER BY id
+                        LIMIT 1
+                        """
+                    ),
+                    {"portrait_id": resolved_portrait_id},
+                )
+                active = active_result.mappings().first()
+                if active is not None:
+                    return dict(active)
             result = await conn.execute(
                 text(
                     f"""
                     INSERT INTO {JOB_TABLE} (
                         tenant_id, session_id, session_name, speaker_id, speaker_name,
                         connection_id, external_session_id, status, days_limit, max_messages,
-                        mode, since_timestamp, created_at, updated_at
+                        mode, since_timestamp, portrait_id, claimed_pending_messages,
+                        created_at, updated_at
                     ) VALUES (
                         :tenant_id, :session_id, :session_name, :speaker_id, :speaker_name,
                         :connection_id, :external_session_id, 'queued', :days_limit, :max_messages,
-                        :mode, :since_timestamp, :now, :now
+                        :mode, :since_timestamp, :portrait_id, :claimed_pending_messages,
+                        :now, :now
                     )
                     RETURNING id
                     """
@@ -91,11 +141,13 @@ class SpeakerPortraitStore:
                     "speaker_id": speaker_id,
                     "speaker_name": speaker_name,
                     "connection_id": connection_id,
-                    "external_session_id": external_session_id,
+                    "external_session_id": resolved_external_session_id,
                     "days_limit": days_limit,
                     "max_messages": max_messages,
                     "mode": normalized_mode,
-                    "since_timestamp": str(since_timestamp or "")[:64],
+                    "since_timestamp": resolved_since[:64],
+                    "portrait_id": resolved_portrait_id,
+                    "claimed_pending_messages": max(0, int(resolved_pending or 0)),
                     "now": _now(),
                 },
             )
@@ -208,6 +260,23 @@ class SpeakerPortraitStore:
     ) -> dict[str, Any]:
         now = _now()
         async with get_engine().begin() as conn:
+            job_state = await conn.execute(
+                text(
+                    f"""
+                    SELECT claimed_pending_messages
+                    FROM {JOB_TABLE}
+                    WHERE id = :job_id
+                    FOR UPDATE
+                    """
+                ),
+                {"job_id": job_id},
+            )
+            job_row = job_state.mappings().first()
+            claimed_pending_messages = (
+                max(0, int(job_row["claimed_pending_messages"] or 0))
+                if job_row is not None
+                else 0
+            )
             existing = await conn.execute(
                 text(
                     f"""
@@ -255,7 +324,12 @@ class SpeakerPortraitStore:
                     text(
                         f"""
                         UPDATE {PORTRAIT_TABLE}
-                        SET display_name = :display_name, session_id = :session_id,
+                        SET display_name = :display_name,
+                            session_id = CASE
+                                WHEN :session_id <> '' AND :session_id NOT LIKE 'cx1:%'
+                                    THEN :session_id
+                                ELSE session_id
+                            END,
                             status = 'ready', updated_at = :now
                         WHERE id = :id
                         """
@@ -295,9 +369,22 @@ class SpeakerPortraitStore:
                     UPDATE {PORTRAIT_TABLE}
                     SET current_revision_id = :revision_id,
                         last_message_at = CASE
-                            WHEN :last_message_at <> '' THEN :last_message_at
+                            WHEN :last_message_at <> '' AND (
+                                last_message_at = '' OR :last_message_at > last_message_at
+                            ) THEN :last_message_at
                             ELSE last_message_at
                         END,
+                        last_distilled_message_at = CASE
+                            WHEN :last_message_at <> '' AND (
+                                last_distilled_message_at = ''
+                                OR :last_message_at > last_distilled_message_at
+                            ) THEN :last_message_at
+                            ELSE last_distilled_message_at
+                        END,
+                        pending_messages = GREATEST(
+                            pending_messages - :claimed_pending_messages,
+                            0
+                        ),
                         last_full_at = CASE
                             WHEN :mode = 'full' THEN :now
                             ELSE last_full_at
@@ -310,6 +397,7 @@ class SpeakerPortraitStore:
                     "revision_id": revision_id,
                     "last_message_at": str(last_message_at or "")[:64],
                     "mode": "incremental" if str(mode or "") == "incremental" else "full",
+                    "claimed_pending_messages": claimed_pending_messages,
                     "now": now,
                     "id": portrait_id,
                 },
@@ -433,14 +521,16 @@ class SpeakerPortraitStore:
                             ELSE display_name
                         END,
                         session_id = CASE
-                            WHEN :session_id <> '' THEN :session_id
+                            WHEN :session_id <> '' AND :session_id NOT LIKE 'cx1:%'
+                                THEN :session_id
                             ELSE session_id
                         END,
                         last_message_at = CASE
-                            WHEN :timestamp <> '' THEN :timestamp
+                            WHEN :timestamp <> '' AND (
+                                last_message_at = '' OR :timestamp > last_message_at
+                            ) THEN :timestamp
                             ELSE last_message_at
-                        END,
-                        updated_at = :now
+                        END
                     WHERE tenant_id = :tenant_id AND channel = :channel
                       AND source_key = :source_key AND speaker_id = :speaker_id
                       AND hot_update_enabled IS TRUE
@@ -450,7 +540,6 @@ class SpeakerPortraitStore:
                     "speaker_name": str(speaker_name or "")[:256],
                     "session_id": str(session_id or "")[:256],
                     "timestamp": str(timestamp or "")[:64],
-                    "now": _now(),
                     "tenant_id": tenant_id,
                     "channel": channel,
                     "source_key": source_key,
@@ -481,9 +570,14 @@ class SpeakerPortraitStore:
                       )
                       AND NOT EXISTS (
                         SELECT 1 FROM {JOB_TABLE} j
-                        WHERE j.tenant_id = p.tenant_id
-                          AND j.speaker_id = p.speaker_id
-                          AND j.status IN ('queued', 'running')
+                        WHERE j.portrait_id = p.id
+                          AND (
+                            j.status IN ('queued', 'running')
+                            OR (
+                              j.mode = 'incremental'
+                              AND j.created_at > :cutoff
+                            )
+                          )
                       )
                     ORDER BY p.pending_messages DESC, p.updated_at ASC
                     LIMIT :limit

--- a/plugins/tibo_reset/plugin.py
+++ b/plugins/tibo_reset/plugin.py
@@ -88,9 +88,11 @@ class TiboResetPlugin(Plugin):
         self._execution_gate_confirmed = False
         self._execution_gate_grace_deadline = 0.0
         self._lifecycle_lock = asyncio.Lock()
-        # initialize() overwrites this from the deployment-level setting.
-        # Directly assembled instances retain the historical lifecycle behavior.
+        # Directly assembled instances keep historical lifecycle behavior.
+        # initialize() treats plugin_state as the run switch and the API URL
+        # as configuration, not a second enablement lock.
         self._configured_enabled = True
+        self._api_url_configured = False
 
     def _owns_scheduler_role(self) -> bool:
         if self._ctx is None:
@@ -105,17 +107,17 @@ class TiboResetPlugin(Plugin):
 
     async def initialize(self, ctx: PluginContext) -> None:
         self._ctx = ctx
-        self._configured_enabled = bool(
-            getattr(ctx.settings, "tibo_reset_enabled", False)
-        )
+        api_url = str(getattr(ctx.settings, "tibo_reset_api_url", "") or "").strip()
+        self._api_url_configured = bool(api_url)
+        self._configured_enabled = self._api_url_configured
         self._store = TiboResetStore(ctx.settings)
         if ctx.db_ok:
             await self._store.ensure_tables()
-        if not self._configured_enabled:
+        if not self._api_url_configured:
             self._service = _DisabledTiboResetService(self._store)  # type: ignore[assignment]
             return
         self._client = TiboResetClient(
-            str(getattr(ctx.settings, "tibo_reset_api_url", "") or ""),
+            api_url,
             timeout_seconds=float(
                 getattr(ctx.settings, "tibo_reset_request_timeout_seconds", 15.0)
             ),
@@ -154,6 +156,7 @@ class TiboResetPlugin(Plugin):
             self._store = None
             self._ctx = None
             self._configured_enabled = False
+            self._api_url_configured = False
             self._scheduler_wakeup = asyncio.Event()
             self._scheduler_stop = asyncio.Event()
 
@@ -233,15 +236,15 @@ class TiboResetPlugin(Plugin):
             "scope": "group",
             "label": "Codex Tibo 重置提醒",
             "summary": (
-                "Requires deployment-level TIBO_RESET_ENABLED plus per-group enablement. "
-                "Confirmed history is retained, reset questions are answered, and later "
-                "confirmed entries are forwarded verbatim."
+                "按群启用后会保留已确认的重置记录、回答群里的相关提问，并原样转发新确认条目。"
+                "缺少接口地址时显示未配置，不会当成未安装。"
             ),
         }
 
     async def get_runtime_status(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "configured_enabled": self._configured_enabled,
+            "api_url_configured": self._api_url_configured,
             "running": bool(self._scheduler_task and not self._scheduler_task.done()),
             "scheduler_enabled": self._scheduler_enabled,
             "poll_interval_seconds": self._poll_interval(),

--- a/tests/unit/test_admin_capabilities.py
+++ b/tests/unit/test_admin_capabilities.py
@@ -588,3 +588,89 @@ async def test_capabilities_endpoint_enforces_authentication_and_tenant_scope(
     assert allowed.status_code == 200
     assert forbidden.status_code == 403
     assert forbidden.json()["detail"] == "tenant_scope_forbidden"
+
+
+@pytest.mark.asyncio
+async def test_tibo_reset_reports_unconfigured_when_api_url_is_missing() -> None:
+    registry = _Registry(
+        [
+            _Plugin("wxbot", version="0.2.0"),
+            _Plugin("tibo_reset", dependencies=["wxbot>=0.2.0"]),
+        ]
+    )
+    payload = await build_tenant_capabilities(
+        tenant_id="demo",
+        principal=_principal(),
+        settings=Settings(app_env="test", tibo_reset_api_url=""),
+        plugin_registry=registry,
+        plugin_manager=_ScopeManager(),
+        faq_store=object(),
+        kb_service=object(),
+        dlq_service=object(),
+        stream_service=object(),
+        orchestrator=object(),
+    )
+    tibo = _capability(payload, "plugin.tibo_reset")
+    assert tibo["enabled"] is True
+    assert tibo["health"] == "action_required"
+    assert tibo["status_reason"] == "plugin_not_configured"
+    assert tibo["entry_route"] == "/plugins?plugin=tibo_reset"
+    assert tibo["recovery_actions"][0]["target"] == "/plugins?plugin=tibo_reset"
+    assert tibo["recovery_actions"][0]["label"] == "配置 Tibo Reset 接口地址"
+
+
+@pytest.mark.asyncio
+async def test_tibo_reset_is_ready_when_plugin_state_and_api_url_are_present() -> None:
+    registry = _Registry(
+        [
+            _Plugin("wxbot", version="0.2.0"),
+            _Plugin("tibo_reset", dependencies=["wxbot>=0.2.0"]),
+        ]
+    )
+    payload = await build_tenant_capabilities(
+        tenant_id="demo",
+        principal=_principal(),
+        settings=Settings(
+            app_env="test",
+            tibo_reset_api_url="https://reset-feed.example.invalid/api/resets",
+        ),
+        plugin_registry=registry,
+        plugin_manager=_ScopeManager(),
+        faq_store=object(),
+        kb_service=object(),
+        dlq_service=object(),
+        stream_service=object(),
+        orchestrator=object(),
+    )
+    tibo = _capability(payload, "plugin.tibo_reset")
+    assert tibo["enabled"] is True
+    assert tibo["health"] == "ready"
+    assert tibo["status_reason"] == "plugin_active_for_tenant"
+
+
+@pytest.mark.asyncio
+async def test_tibo_reset_inactive_plugin_state_is_not_unconfigured() -> None:
+    registry = _Registry(
+        [
+            _Plugin("wxbot", version="0.2.0"),
+            _Plugin("tibo_reset", dependencies=["wxbot>=0.2.0"]),
+        ],
+        active={"wxbot"},
+    )
+    payload = await build_tenant_capabilities(
+        tenant_id="demo",
+        principal=_principal(),
+        settings=Settings(app_env="test", tibo_reset_api_url=""),
+        plugin_registry=registry,
+        plugin_manager=_ScopeManager(),
+        faq_store=object(),
+        kb_service=object(),
+        dlq_service=object(),
+        stream_service=object(),
+        orchestrator=object(),
+    )
+    tibo = _capability(payload, "plugin.tibo_reset")
+    assert tibo["enabled"] is False
+    assert tibo["health"] == "action_required"
+    assert tibo["status_reason"] == "plugin_not_active"
+    assert tibo["recovery_actions"][0]["target"] == "/plugins?plugin=tibo_reset"

--- a/tests/unit/test_memory_event_provenance_expiry_migration.py
+++ b/tests/unit/test_memory_event_provenance_expiry_migration.py
@@ -36,7 +36,7 @@ def test_memory_provenance_expiry_upgrade_is_runtime_head(monkeypatch) -> None:
 
     assert migration.revision == "0046_memory_event_provenance_expiry"
     assert migration.down_revision == "0045_wxbot_outbound_files"
-    assert RUNTIME_SCHEMA_REVISION == "0049_speaker_portrait_hot_update"
+    assert RUNTIME_SCHEMA_REVISION == "0050_speaker_portrait_cursor"
     assert RUNTIME_SCHEMA_COMPATIBILITY_LEVEL == 9
     assert ScriptDirectory.from_config(Config("alembic.ini")).get_heads() == [
         RUNTIME_SCHEMA_REVISION

--- a/tests/unit/test_message_effect_producer_owner_migration.py
+++ b/tests/unit/test_message_effect_producer_owner_migration.py
@@ -35,7 +35,7 @@ def test_message_effect_producer_owner_upgrade_is_linear_and_backfilled(
 
     assert migration.revision == "0034_message_effect_producer_owner"
     assert migration.down_revision == "0033_wxbot_event_connection_scope"
-    assert RUNTIME_SCHEMA_REVISION == "0049_speaker_portrait_hot_update"
+    assert RUNTIME_SCHEMA_REVISION == "0050_speaker_portrait_cursor"
     assert RUNTIME_SCHEMA_COMPATIBILITY_LEVEL == 9
     script = ScriptDirectory.from_config(Config("alembic.ini"))
     assert script.get_heads() == [RUNTIME_SCHEMA_REVISION]

--- a/tests/unit/test_persona_job_queue_migration.py
+++ b/tests/unit/test_persona_job_queue_migration.py
@@ -33,7 +33,7 @@ def test_persona_job_queue_upgrade_is_linear_and_fenced(monkeypatch) -> None:
 
     assert migration.revision == "0041_persona_job_queue"
     assert migration.down_revision == "0039_channel_connection_activity"
-    assert RUNTIME_SCHEMA_REVISION == "0049_speaker_portrait_hot_update"
+    assert RUNTIME_SCHEMA_REVISION == "0050_speaker_portrait_cursor"
     assert RUNTIME_SCHEMA_COMPATIBILITY_LEVEL == 9
     assert ScriptDirectory.from_config(Config("alembic.ini")).get_heads() == [
         RUNTIME_SCHEMA_REVISION

--- a/tests/unit/test_persona_profile_catalog_migration.py
+++ b/tests/unit/test_persona_profile_catalog_migration.py
@@ -51,7 +51,7 @@ def test_persona_profile_catalog_upgrade_restores_saved_skill_catalog(
         ScriptDirectory.from_config(Config("alembic.ini"))
         .get_revision(RUNTIME_SCHEMA_REVISION)
         .down_revision
-        == "0048_speaker_portraits"
+        == "0049_speaker_portrait_hot_update"
     )
     assert "LOCK TABLE plugin_persona_profiles IN ACCESS EXCLUSIVE MODE" in rendered
     assert (

--- a/tests/unit/test_repeater_hook.py
+++ b/tests/unit/test_repeater_hook.py
@@ -240,6 +240,23 @@ async def test_repeater_hook_repeats_on_two_identical_user_messages() -> None:
 
 
 @pytest.mark.asyncio
+async def test_repeater_hook_skips_when_group_scope_is_disabled() -> None:
+    store = _FakeRepeaterStore(enabled=True, should_trigger=True)
+
+    async def deny_scope(_tenant_id: str, _session_id: str) -> bool:
+        return False
+
+    hook = RepeaterHook(store, scope_execution_allowed=deny_scope)
+    ctx = _ctx("复读测试", "复读测试")
+
+    await hook.run(ctx)
+
+    assert store.recorded == []
+    assert store.config_session_ids == []
+    assert ctx.extras["repeater"]["reason"] == "scope_disabled"
+
+
+@pytest.mark.asyncio
 async def test_repeater_uses_external_group_id_after_managed_identity_migration() -> None:
     store = _FakeRepeaterStore(enabled=True, should_trigger=True)
     ctx = _ctx("复读测试", "复读测试")

--- a/tests/unit/test_speaker_portrait.py
+++ b/tests/unit/test_speaker_portrait.py
@@ -85,6 +85,27 @@ def test_apply_coverage_caps_confidence_when_unread() -> None:
     assert portrait["coverage"]["complete"] is False
 
 
+def test_apply_coverage_accumulates_incremental_counts() -> None:
+    previous = {
+        "coverage": {"lines_total": 5656, "lines_read": 5656, "complete": True},
+        "confidence": 0.89,
+    }
+    portrait = {
+        "summary": "x",
+        "confidence": 0.89,
+        "confidence_provided": True,
+        "coverage": {"lines_read": 40, "complete": True},
+        "unknowns": [],
+    }
+    apply_coverage(portrait, lines_total=40, previous=previous, mode="incremental")
+    assert portrait["coverage"] == {
+        "lines_total": 5696,
+        "lines_read": 5696,
+        "complete": True,
+    }
+    assert portrait["confidence"] == 0.89
+
+
 def test_apply_coverage_fills_missing_confidence_when_complete() -> None:
     portrait = {
         "summary": "x",

--- a/tests/unit/test_speaker_portrait.py
+++ b/tests/unit/test_speaker_portrait.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
 from app.common.prompting import augment_prompt_with_persona_and_memory
 from app.common.types import Channel, Session
+from plugins.speaker_portrait.jobs import sync_applied_styles
 from plugins.speaker_portrait.pipeline import (
     apply_coverage,
     build_portrait_prompt,
@@ -188,6 +191,71 @@ def test_compile_reply_style_uses_first_person_and_examples() -> None:
     assert "带带我" in prompt
     assert "烤鱼" in prompt
     assert "按自己平时怎么过、最近在忙什么来答" in prompt
+
+
+class _FakePersonaStore:
+    def __init__(self, profiles: list[dict]) -> None:
+        self.profiles = profiles
+        self.slug_queries: list[tuple[str, str]] = []
+        self.upserts: list[dict] = []
+
+    async def list_profiles_by_slug(self, tenant_id: str, skill_slug: str) -> list[dict]:
+        self.slug_queries.append((tenant_id, skill_slug))
+        return list(self.profiles)
+
+    async def upsert_profile(self, **kwargs) -> dict:
+        self.upserts.append(kwargs)
+        return {"id": kwargs.get("profile_id"), **kwargs}
+
+
+@pytest.mark.asyncio
+async def test_style_sync_recompiles_applied_profiles() -> None:
+    store = _FakePersonaStore(
+        [
+            {
+                "id": 7,
+                "session_id": "room@chatroom",
+                "channel": "wechat",
+                "source_key": "wxbot",
+                "source_label": "小海",
+                "profile_name": "小海",
+                "target_name": "小海",
+                "target_user_id": "wxid_hai",
+                "enabled": True,
+            }
+        ]
+    )
+    synced = await sync_applied_styles(
+        object(),
+        tenant_id="demo",
+        speaker_id="wxid_hai",
+        speaker_name="小海",
+        portrait={"summary": "爱吃烤鱼的打工人", "likes": [{"text": "烤鱼", "count": 9}]},
+        persona_store=store,  # type: ignore[arg-type]
+    )
+    assert synced == 1
+    assert store.slug_queries == [("demo", "portrait-wxid-hai")]
+    upsert = store.upserts[0]
+    assert upsert["profile_id"] == 7
+    assert upsert["enabled"] is True
+    assert upsert["skill_slug"] == "portrait-wxid-hai"
+    assert "你就是小海" in upsert["prompt_text"]
+    assert "烤鱼" in upsert["prompt_text"]
+
+
+@pytest.mark.asyncio
+async def test_style_sync_without_applied_profiles_is_noop() -> None:
+    store = _FakePersonaStore([])
+    synced = await sync_applied_styles(
+        object(),
+        tenant_id="demo",
+        speaker_id="wxid_hai",
+        speaker_name="小海",
+        portrait={"summary": "x"},
+        persona_store=store,  # type: ignore[arg-type]
+    )
+    assert synced == 0
+    assert store.upserts == []
 
 
 def test_prompt_includes_speaker_portrait_without_imitation() -> None:

--- a/tests/unit/test_speaker_portrait_cursor_migration.py
+++ b/tests/unit/test_speaker_portrait_cursor_migration.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from importlib import import_module
+from io import StringIO
+
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+
+from app.infra.runtime_schema import (
+    RUNTIME_SCHEMA_COLUMN_CONTRACTS,
+    RUNTIME_SCHEMA_INDEXES,
+    RUNTIME_SCHEMA_REVISION,
+)
+
+_MODULE = "migrations.versions.20260902_0050_speaker_portrait_incremental_cursor"
+
+
+def _render(monkeypatch, operation: str) -> tuple[object, str]:
+    migration = import_module(_MODULE)
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="postgresql",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    monkeypatch.setattr(migration, "op", Operations(context))
+    getattr(migration, operation)()
+    return migration, output.getvalue()
+
+
+def test_speaker_portrait_cursor_upgrade_is_runtime_head(monkeypatch) -> None:
+    migration, rendered = _render(monkeypatch, "upgrade")
+
+    assert migration.revision == "0050_speaker_portrait_cursor"
+    assert migration.down_revision == "0049_speaker_portrait_hot_update"
+    assert RUNTIME_SCHEMA_REVISION == migration.revision
+    assert ScriptDirectory.from_config(Config("alembic.ini")).get_heads() == [
+        RUNTIME_SCHEMA_REVISION
+    ]
+    assert "ADD COLUMN IF NOT EXISTS last_distilled_message_at" in rendered
+    assert "ADD COLUMN IF NOT EXISTS claimed_pending_messages" in rendered
+    assert "CREATE INDEX IF NOT EXISTS idx_speaker_portrait_job_attempt" in rendered
+    assert (
+        "plugin_speaker_portraits",
+        "last_distilled_message_at",
+        False,
+    ) in RUNTIME_SCHEMA_COLUMN_CONTRACTS
+    assert (
+        "plugin_speaker_portrait_jobs",
+        "claimed_pending_messages",
+        False,
+    ) in RUNTIME_SCHEMA_COLUMN_CONTRACTS
+    assert "idx_speaker_portrait_job_attempt" in RUNTIME_SCHEMA_INDEXES
+
+
+def test_speaker_portrait_cursor_downgrade_removes_new_contract(monkeypatch) -> None:
+    _migration, rendered = _render(monkeypatch, "downgrade")
+
+    assert "DROP INDEX IF EXISTS idx_speaker_portrait_job_attempt" in rendered
+    assert "DROP COLUMN IF EXISTS claimed_pending_messages" in rendered
+    assert "DROP COLUMN IF EXISTS last_distilled_message_at" in rendered

--- a/tests/unit/test_speaker_portrait_hot_update.py
+++ b/tests/unit/test_speaker_portrait_hot_update.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.common.types import Channel, InboundEvent, Message
+from app.orchestrator.pipeline import PipelineContext
+from plugins.speaker_portrait.hooks import SpeakerPortraitNoteStep, _external_session_id
+from plugins.speaker_portrait.plugin import SpeakerPortraitPlugin
+
+
+def _event(*, external_session_id: str = "53876528317@chatroom", content: str = "hello") -> InboundEvent:
+    return InboundEvent(
+        message_id="message-1",
+        tenant_id="default",
+        channel=Channel.WECHAT,
+        adapter_id="wechat-sdk",
+        connection_id="connection-1",
+        user_id="cx1:p:user",
+        session_id="cx1:c:canonical@chatroom",
+        external_conversation_id=external_session_id,
+        external_user_id="wxid_hai",
+        message=Message(content=content),
+        metadata={"sender_wxid": "wxid_hai", "sender_name": "小海"},
+    )
+
+
+def test_portrait_session_id_prefers_sdk_external_identity() -> None:
+    ctx = PipelineContext(event=_event(), trace_id="trace-1")
+
+    assert _external_session_id(ctx) == "53876528317@chatroom"
+
+
+def test_portrait_session_id_does_not_persist_canonical_fallback() -> None:
+    ctx = PipelineContext(event=_event(external_session_id=""), trace_id="trace-1")
+
+    assert _external_session_id(ctx) == ""
+
+
+class _NoteStore:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def note_speaker_message(self, **kwargs) -> bool:
+        self.calls.append(kwargs)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_note_step_uses_external_session_and_only_counts_text() -> None:
+    store = _NoteStore()
+    step = SpeakerPortraitNoteStep(store)  # type: ignore[arg-type]
+
+    result = await step.run(PipelineContext(event=_event(), trace_id="trace-1"))
+    empty = await step.run(
+        PipelineContext(event=_event(content=""), trace_id="trace-2")
+    )
+
+    assert result.reason == "noted"
+    assert store.calls[0]["session_id"] == "53876528317@chatroom"
+    assert empty.reason == "no_text"
+    assert len(store.calls) == 1
+
+
+class _HotUpdateStore:
+    def __init__(self) -> None:
+        self.created: list[dict] = []
+
+    async def due_hot_updates(self, **_kwargs) -> list[dict]:
+        return [
+            {
+                "id": 7,
+                "tenant_id": "default",
+                "session_id": "53876528317@chatroom",
+                "speaker_id": "wxid_hai",
+                "display_name": "小海",
+                "pending_messages": 37,
+                "last_distilled_message_at": "2026-08-27T07:00:00+00:00",
+            }
+        ]
+
+    async def create_job(self, **kwargs) -> dict:
+        self.created.append(kwargs)
+        return {"id": 8, "status": "queued"}
+
+
+@pytest.mark.asyncio
+async def test_hot_update_keeps_pending_until_success_and_uses_distilled_cursor() -> None:
+    store = _HotUpdateStore()
+    plugin = SpeakerPortraitPlugin()
+    plugin._store = store  # type: ignore[assignment]
+    plugin._ctx = SimpleNamespace(
+        settings=SimpleNamespace(
+            speaker_portrait_hot_update_min_messages=40,
+            speaker_portrait_hot_update_min_seconds=3600.0,
+        )
+    )
+
+    await plugin._enqueue_hot_updates()
+
+    assert store.created == [
+        {
+            "tenant_id": "default",
+            "session_id": "53876528317@chatroom",
+            "session_name": "53876528317@chatroom",
+            "speaker_id": "wxid_hai",
+            "speaker_name": "小海",
+            "external_session_id": "53876528317@chatroom",
+            "days_limit": 14,
+            "max_messages": 800,
+            "mode": "incremental",
+            "since_timestamp": "2026-08-27T07:00:00+00:00",
+            "portrait_id": 7,
+            "claimed_pending_messages": 37,
+        }
+    ]

--- a/tests/unit/test_tibo_reset_plugin_router.py
+++ b/tests/unit/test_tibo_reset_plugin_router.py
@@ -200,7 +200,6 @@ async def test_tibo_reset_plugin_only_schedules_in_scheduler_process(
     worker_plugin = module.TiboResetPlugin()
     worker_settings = SimpleNamespace(
         app_process_role="inbound",
-        tibo_reset_enabled=True,
         tibo_reset_api_url="https://tibo-reset.test/api/resets",
         tibo_reset_request_timeout_seconds=1,
         tibo_reset_poll_interval_seconds=30,
@@ -262,13 +261,13 @@ async def test_tibo_reset_plugin_only_schedules_in_scheduler_process(
 
 
 @pytest.mark.asyncio
-async def test_tibo_reset_plugin_is_inert_without_deployment_opt_in(
+async def test_tibo_reset_plugin_is_inert_without_api_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import plugins.tibo_reset.plugin as module
 
     def unexpected_dependency(*_args, **_kwargs):
-        raise AssertionError("disabled plugin must not initialize outbound dependencies")
+        raise AssertionError("unconfigured plugin must not initialize outbound dependencies")
 
     _PluginStore.ensured = 0
     monkeypatch.setattr(module, "TiboResetStore", _PluginStore)
@@ -283,7 +282,7 @@ async def test_tibo_reset_plugin_is_inert_without_deployment_opt_in(
             container=SimpleNamespace(),
             settings=SimpleNamespace(
                 app_process_role="scheduler",
-                tibo_reset_enabled=False,
+                tibo_reset_api_url="",
             ),
             db_ok=True,
             redis_ok=False,
@@ -292,6 +291,7 @@ async def test_tibo_reset_plugin_is_inert_without_deployment_opt_in(
 
     status = await disabled_plugin.get_runtime_status()
     assert status["configured_enabled"] is False
+    assert status["api_url_configured"] is False
     assert status["scheduler_enabled"] is False
     assert _PluginStore.ensured == 1
     assert disabled_plugin.get_api_router() is not None


### PR DESCRIPTION
## Summary
- make speaker portraits the primary reply-style source and keep persona profiles synchronized
- add lossless incremental portrait updates with a durable cursor and atomic pending claims
- restyle the console with the Ink & Pine design system and shared layouts
- make plugin enablement/status reporting reflect actual runtime configuration
- repair plugin page request typing, SPA navigation, and unconfigured-state handling
- tighten repeater and Tibo plugin scope/status behavior

## Verification
- 66 targeted backend tests passed
- 32 targeted frontend tests passed
- TypeScript typecheck passed
- CSS lint passed

## Review note
This is the broadest PR because the existing console restyle commit touched shared layout plus most operational pages. Follow-up relationship-graph and media-cache changes are intentionally separated into stacked PRs.