### PR TITLE
fix: make protected image previews stable and bounded

### DIFF
--- a/frontend/src/components/AuthenticatedImage.test.tsx
+++ b/frontend/src/components/AuthenticatedImage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { apiBlobRequest } from "../lib/api";
@@ -10,21 +10,24 @@ import {
   sdkImageProxyPath,
 } from "./AuthenticatedImage";
 
+const { mockConfig } = vi.hoisted(() => ({
+  mockConfig: {
+    apiBaseUrl: "http://localhost",
+    adminToken: "test-admin-token",
+    tenantId: "default",
+    sessionId: "",
+    userId: "operator",
+  },
+}));
+
 vi.mock("../lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/api")>();
   return { ...actual, apiBlobRequest: vi.fn() };
 });
 
 vi.mock("../state/console-config", () => ({
-  useConsoleConfig: () => ({
-    config: {
-      apiBaseUrl: "http://localhost",
-      adminToken: "test-admin-token",
-      tenantId: "default",
-      sessionId: "",
-      userId: "operator",
-    },
-  }),
+  COOKIE_SESSION_MARKER: "__agent_console_cookie_session__",
+  useConsoleConfig: () => ({ config: mockConfig }),
 }));
 
 const apiBlobRequestMock = vi.mocked(apiBlobRequest);
@@ -51,6 +54,10 @@ function signedImage(locator: string, expiresAt: number, signature = "sig") {
   );
 }
 
+function futureExpiry(offsetSeconds = 300) {
+  return Math.floor(Date.now() / 1000) + offsetSeconds;
+}
+
 describe("AuthenticatedImage media identifiers", () => {
   const mediaId = "mid1.payload.signature";
 
@@ -70,7 +77,7 @@ describe("AuthenticatedImage media identifiers", () => {
     expect(sdkImageProxyPath("../../etc/passwd")).toBe("");
   });
 
-  it("keeps a stable cache key when only the signed expiry changes", () => {
+  it("keeps a stable locator key when only the signed expiry changes", () => {
     const first = signedImage("generated/example.png", 1_700_000_100);
     const second = signedImage("generated/example.png", 1_700_000_105, "other");
     expect(mediaStableKey(first)).toBe(mediaStableKey(`media:${second}`));
@@ -82,17 +89,30 @@ describe("AuthenticatedImage media identifiers", () => {
 });
 
 describe("AuthenticatedImage loading", () => {
+  let nextObjectUrl = 0;
+
   beforeEach(() => {
     resetAuthenticatedImageCache();
     apiBlobRequestMock.mockReset();
-    URL.createObjectURL = vi.fn(() => "blob:test-image");
+    Object.assign(mockConfig, {
+      apiBaseUrl: "http://localhost",
+      adminToken: "test-admin-token",
+      tenantId: "default",
+      sessionId: "",
+      userId: "operator",
+    });
+    nextObjectUrl = 0;
+    URL.createObjectURL = vi.fn(() => `blob:test-image-${++nextObjectUrl}`);
+    URL.revokeObjectURL = vi.fn();
   });
 
   afterEach(() => {
     resetAuthenticatedImageCache();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
-  it("does not refetch when a refresh only rotates the signed media id", async () => {
+  it("deduplicates an in-flight request when only the signed media id rotates", async () => {
     let resolveBlob: ((blob: Blob) => void) | undefined;
     apiBlobRequestMock.mockImplementation(
       () =>
@@ -101,7 +121,7 @@ describe("AuthenticatedImage loading", () => {
         }),
     );
 
-    const first = signedImage("generated/example.png", 1_700_000_100);
+    const first = signedImage("generated/example.png", futureExpiry());
     const { rerender } = render(
       <AuthenticatedImage source={first} alt="消息图片" className="queue-image-preview" />,
     );
@@ -109,7 +129,7 @@ describe("AuthenticatedImage loading", () => {
 
     rerender(
       <AuthenticatedImage
-        source={signedImage("generated/example.png", 1_700_000_105, "rotated")}
+        source={signedImage("generated/example.png", futureExpiry(600), "rotated")}
         alt="消息图片"
         className="queue-image-preview"
       />,
@@ -119,14 +139,13 @@ describe("AuthenticatedImage loading", () => {
     resolveBlob?.(new Blob(["image-bytes"], { type: "image/png" }));
     expect(await screen.findByRole("img", { name: "消息图片" })).toHaveAttribute(
       "src",
-      "blob:test-image",
+      "blob:test-image-1",
     );
-    expect(screen.queryByText("加载中")).not.toBeInTheDocument();
   });
 
-  it("reuses a cached blob across remounts of the same locator", async () => {
+  it("reuses a fresh cached blob across remounts of the same locator", async () => {
     apiBlobRequestMock.mockResolvedValue(new Blob(["image-bytes"], { type: "image/png" }));
-    const source = signedImage("generated/example.png", 1_700_000_100);
+    const source = signedImage("generated/example.png", futureExpiry());
     const { unmount } = render(
       <AuthenticatedImage source={source} alt="消息图片" className="queue-image-preview" />,
     );
@@ -135,20 +154,178 @@ describe("AuthenticatedImage loading", () => {
 
     render(
       <AuthenticatedImage
-        source={signedImage("generated/example.png", 1_700_000_200, "later")}
+        source={signedImage("generated/example.png", futureExpiry(600), "later")}
         alt="消息图片"
         className="queue-image-preview"
       />,
     );
-    expect(screen.getByRole("img", { name: "消息图片" })).toHaveAttribute("src", "blob:test-image");
+    expect(await screen.findByRole("img", { name: "消息图片" })).toHaveAttribute(
+      "src",
+      "blob:test-image-1",
+    );
     expect(apiBlobRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates cache entries by backend, admin credential, tenant, and user", async () => {
+    apiBlobRequestMock.mockResolvedValue(new Blob(["image-bytes"], { type: "image/png" }));
+    const source = signedImage("generated/scoped.png", futureExpiry());
+    const { rerender } = render(
+      <AuthenticatedImage source={source} alt="隔离图片" className="queue-image-preview" />,
+    );
+    await screen.findByRole("img", { name: "隔离图片" });
+
+    mockConfig.apiBaseUrl = "https://other-backend.example";
+    rerender(<AuthenticatedImage source={source} alt="隔离图片" className="queue-image-preview" />);
+    await waitFor(() => expect(screen.getByRole("img", { name: "隔离图片" })).toHaveAttribute("src", "blob:test-image-2"));
+
+    mockConfig.adminToken = "other-admin-token";
+    rerender(<AuthenticatedImage source={source} alt="隔离图片" className="queue-image-preview" />);
+    await waitFor(() => expect(screen.getByRole("img", { name: "隔离图片" })).toHaveAttribute("src", "blob:test-image-3"));
+
+    mockConfig.tenantId = "other-tenant";
+    rerender(<AuthenticatedImage source={source} alt="隔离图片" className="queue-image-preview" />);
+    await waitFor(() => expect(screen.getByRole("img", { name: "隔离图片" })).toHaveAttribute("src", "blob:test-image-4"));
+
+    mockConfig.userId = "other-operator";
+    rerender(<AuthenticatedImage source={source} alt="隔离图片" className="queue-image-preview" />);
+    await waitFor(() => expect(screen.getByRole("img", { name: "隔离图片" })).toHaveAttribute("src", "blob:test-image-5"));
+    expect(apiBlobRequestMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("does not retain opaque cookie-session blobs after the last image unmounts", async () => {
+    mockConfig.adminToken = "__agent_console_cookie_session__";
+    apiBlobRequestMock.mockResolvedValue(new Blob(["image-bytes"], { type: "image/png" }));
+    const source = signedImage("generated/cookie-session.png", futureExpiry());
+    const first = render(
+      <AuthenticatedImage source={source} alt="会话图片" className="queue-image-preview" />,
+    );
+    await screen.findByRole("img", { name: "会话图片" });
+
+    first.unmount();
+    await Promise.resolve();
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-image-1");
+    render(<AuthenticatedImage source={source} alt="会话图片" className="queue-image-preview" />);
+    await waitFor(() => expect(screen.getByRole("img", { name: "会话图片" })).toHaveAttribute("src", "blob:test-image-2"));
+    expect(apiBlobRequestMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("revalidates after the signed id expires and revokes the stale object URL", async () => {
+    const nowMs = 1_900_000_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    apiBlobRequestMock.mockResolvedValue(new Blob(["image-bytes"], { type: "image/png" }));
+    const first = signedImage("generated/expiring.png", Math.floor(nowMs / 1000) + 30);
+    const { unmount } = render(
+      <AuthenticatedImage source={first} alt="过期图片" className="queue-image-preview" />,
+    );
+    await screen.findByRole("img", { name: "过期图片" });
+    unmount();
+
+    dateNow.mockReturnValue(nowMs + 31_000);
+    render(
+      <AuthenticatedImage
+        source={signedImage("generated/expiring.png", Math.floor(nowMs / 1000) + 300, "rotated")}
+        alt="过期图片"
+        className="queue-image-preview"
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole("img", { name: "过期图片" })).toHaveAttribute("src", "blob:test-image-2"));
+    expect(apiBlobRequestMock).toHaveBeenCalledTimes(2);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-image-1");
+  });
+
+  it("periodically revalidates a still-mounted image instead of retaining it indefinitely", async () => {
+    const nowMs = 1_900_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(nowMs);
+    apiBlobRequestMock.mockResolvedValue(new Blob(["image-bytes"], { type: "image/png" }));
+    render(
+      <AuthenticatedImage
+        source={signedImage("generated/revalidate.png", Math.floor(nowMs / 1000) + 300)}
+        alt="重验图片"
+        className="queue-image-preview"
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("img", { name: "重验图片" })).toHaveAttribute(
+      "src",
+      "blob:test-image-1",
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(apiBlobRequestMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole("img", { name: "重验图片" })).toHaveAttribute(
+      "src",
+      "blob:test-image-2",
+    );
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-image-1");
+  });
+
+  it("bounds the cache and revokes the least-recently-used object URL", async () => {
+    apiBlobRequestMock.mockResolvedValue(new Blob(["image-bytes"], { type: "image/png" }));
+    render(
+      <>
+        {Array.from({ length: 65 }, (_, index) => (
+          <AuthenticatedImage
+            key={index}
+            source={signedImage(`generated/cache-${index}.png`, futureExpiry())}
+            alt={`缓存图片 ${index}`}
+            className="queue-image-preview"
+          />
+        ))}
+      </>,
+    );
+
+    await waitFor(() => expect(apiBlobRequestMock).toHaveBeenCalledTimes(65));
+    await screen.findByRole("img", { name: "缓存图片 64" });
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-image-1");
+  });
+
+  it("revokes every cached object URL when the cache is reset", async () => {
+    apiBlobRequestMock.mockResolvedValue(new Blob(["image-bytes"], { type: "image/png" }));
+    render(
+      <AuthenticatedImage
+        source={signedImage("generated/reset.png", futureExpiry())}
+        alt="重置图片"
+        className="queue-image-preview"
+      />,
+    );
+    await screen.findByRole("img", { name: "重置图片" });
+
+    resetAuthenticatedImageCache();
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-image-1");
+  });
+
+  it("replaces a broken img element with the failure placeholder", async () => {
+    apiBlobRequestMock.mockResolvedValue(new Blob(["broken-image"], { type: "image/png" }));
+    render(
+      <AuthenticatedImage
+        source={signedImage("generated/broken.png", futureExpiry())}
+        alt="损坏图片"
+        className="queue-image-preview"
+      />,
+    );
+    const image = await screen.findByRole("img", { name: "损坏图片" });
+
+    fireEvent.error(image);
+
+    expect(screen.queryByRole("img", { name: "损坏图片" })).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("预览失败");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-image-1");
   });
 
   it("shows a failure state when the proxy cannot load the image", async () => {
     apiBlobRequestMock.mockRejectedValue(new Error("proxy failed"));
     render(
       <AuthenticatedImage
-        source={signedImage("generated/missing.png", 1_700_000_100)}
+        source={signedImage("generated/missing.png", futureExpiry())}
         alt="消息图片"
         className="queue-image-preview"
       />,

--- a/frontend/src/components/AuthenticatedImage.test.tsx
+++ b/frontend/src/components/AuthenticatedImage.test.tsx
@@ -1,6 +1,55 @@
-import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { sdkImageDisplayPath, sdkImageProxyPath } from "./AuthenticatedImage";
+import { apiBlobRequest } from "../lib/api";
+import {
+  AuthenticatedImage,
+  mediaStableKey,
+  resetAuthenticatedImageCache,
+  sdkImageDisplayPath,
+  sdkImageProxyPath,
+} from "./AuthenticatedImage";
+
+vi.mock("../lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/api")>();
+  return { ...actual, apiBlobRequest: vi.fn() };
+});
+
+vi.mock("../state/console-config", () => ({
+  useConsoleConfig: () => ({
+    config: {
+      apiBaseUrl: "http://localhost",
+      adminToken: "test-admin-token",
+      tenantId: "default",
+      sessionId: "",
+      userId: "operator",
+    },
+  }),
+}));
+
+const apiBlobRequestMock = vi.mocked(apiBlobRequest);
+
+function encodeMid1(payload: Record<string, unknown>, signature = "sig") {
+  const encoded = btoa(JSON.stringify(payload))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `mid1.${encoded}.${signature}`;
+}
+
+function signedImage(locator: string, expiresAt: number, signature = "sig") {
+  return encodeMid1(
+    {
+      e: expiresAt,
+      k: "sdk_path",
+      l: locator,
+      r: "image",
+      t: "default",
+      v: 1,
+    },
+    signature,
+  );
+}
 
 describe("AuthenticatedImage media identifiers", () => {
   const mediaId = "mid1.payload.signature";
@@ -19,5 +68,91 @@ describe("AuthenticatedImage media identifiers", () => {
     expect(sdkImageProxyPath("/images/generated/example.png")).toBe("");
     expect(sdkImageProxyPath("http://127.0.0.1:5080/images/example.png")).toBe("");
     expect(sdkImageProxyPath("../../etc/passwd")).toBe("");
+  });
+
+  it("keeps a stable cache key when only the signed expiry changes", () => {
+    const first = signedImage("generated/example.png", 1_700_000_100);
+    const second = signedImage("generated/example.png", 1_700_000_105, "other");
+    expect(mediaStableKey(first)).toBe(mediaStableKey(`media:${second}`));
+    expect(mediaStableKey(first)).toBe("mid1:default:sdk_path:image:generated/example.png");
+    expect(mediaStableKey(signedImage("generated/other.png", 1_700_000_100))).not.toBe(
+      mediaStableKey(first),
+    );
+  });
+});
+
+describe("AuthenticatedImage loading", () => {
+  beforeEach(() => {
+    resetAuthenticatedImageCache();
+    apiBlobRequestMock.mockReset();
+    URL.createObjectURL = vi.fn(() => "blob:test-image");
+  });
+
+  afterEach(() => {
+    resetAuthenticatedImageCache();
+  });
+
+  it("does not refetch when a refresh only rotates the signed media id", async () => {
+    let resolveBlob: ((blob: Blob) => void) | undefined;
+    apiBlobRequestMock.mockImplementation(
+      () =>
+        new Promise<Blob>((resolve) => {
+          resolveBlob = resolve;
+        }),
+    );
+
+    const first = signedImage("generated/example.png", 1_700_000_100);
+    const { rerender } = render(
+      <AuthenticatedImage source={first} alt="消息图片" className="queue-image-preview" />,
+    );
+    expect(screen.getByText("加载中")).toBeInTheDocument();
+
+    rerender(
+      <AuthenticatedImage
+        source={signedImage("generated/example.png", 1_700_000_105, "rotated")}
+        alt="消息图片"
+        className="queue-image-preview"
+      />,
+    );
+
+    expect(apiBlobRequestMock).toHaveBeenCalledTimes(1);
+    resolveBlob?.(new Blob(["image-bytes"], { type: "image/png" }));
+    expect(await screen.findByRole("img", { name: "消息图片" })).toHaveAttribute(
+      "src",
+      "blob:test-image",
+    );
+    expect(screen.queryByText("加载中")).not.toBeInTheDocument();
+  });
+
+  it("reuses a cached blob across remounts of the same locator", async () => {
+    apiBlobRequestMock.mockResolvedValue(new Blob(["image-bytes"], { type: "image/png" }));
+    const source = signedImage("generated/example.png", 1_700_000_100);
+    const { unmount } = render(
+      <AuthenticatedImage source={source} alt="消息图片" className="queue-image-preview" />,
+    );
+    await screen.findByRole("img", { name: "消息图片" });
+    unmount();
+
+    render(
+      <AuthenticatedImage
+        source={signedImage("generated/example.png", 1_700_000_200, "later")}
+        alt="消息图片"
+        className="queue-image-preview"
+      />,
+    );
+    expect(screen.getByRole("img", { name: "消息图片" })).toHaveAttribute("src", "blob:test-image");
+    expect(apiBlobRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a failure state when the proxy cannot load the image", async () => {
+    apiBlobRequestMock.mockRejectedValue(new Error("proxy failed"));
+    render(
+      <AuthenticatedImage
+        source={signedImage("generated/missing.png", 1_700_000_100)}
+        alt="消息图片"
+        className="queue-image-preview"
+      />,
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent("预览失败");
   });
 });

--- a/frontend/src/components/AuthenticatedImage.tsx
+++ b/frontend/src/components/AuthenticatedImage.tsx
@@ -10,6 +10,9 @@ type AuthenticatedImageProps = {
   loading?: "eager" | "lazy";
 };
 
+const blobUrlCache = new Map<string, string>();
+const inflight = new Map<string, Promise<string>>();
+
 function mediaIdFromLocator(source: string) {
   const value = source.trim();
   if (!value) {
@@ -17,6 +20,40 @@ function mediaIdFromLocator(source: string) {
   }
   const mediaId = value.startsWith("media:") ? value.slice("media:".length) : value;
   return /^mid1\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(mediaId) ? mediaId : "";
+}
+
+function decodeMid1Payload(mediaId: string): Record<string, unknown> | null {
+  const parts = mediaId.split(".");
+  if (parts.length < 3 || parts[0] !== "mid1") {
+    return null;
+  }
+  try {
+    const padded = parts[1] + "=".repeat((4 - (parts[1].length % 4)) % 4);
+    const json = atob(padded.replace(/-/g, "+").replace(/_/g, "/"));
+    const payload = JSON.parse(json) as unknown;
+    if (!payload || typeof payload !== "object") {
+      return null;
+    }
+    return payload as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function mediaStableKey(source: string) {
+  const trimmed = source.trim();
+  const mediaId = mediaIdFromLocator(trimmed);
+  if (!mediaId) {
+    return trimmed;
+  }
+  const payload = decodeMid1Payload(mediaId);
+  if (!payload || typeof payload.l !== "string" || !payload.l) {
+    return mediaId;
+  }
+  const tenant = typeof payload.t === "string" ? payload.t : "";
+  const kind = typeof payload.k === "string" ? payload.k : "";
+  const role = typeof payload.r === "string" ? payload.r : "image";
+  return `mid1:${tenant}:${kind}:${role}:${payload.l}`;
 }
 
 export function sdkImageProxyPath(source: string) {
@@ -31,17 +68,48 @@ export function sdkImageDisplayPath(source: string) {
   return mediaIdFromLocator(source) ? "受保护媒体" : source;
 }
 
+export function resetAuthenticatedImageCache() {
+  blobUrlCache.clear();
+  inflight.clear();
+}
+
+function loadAuthenticatedBlob(cacheKey: string, proxyPath: string, config: ReturnType<typeof useConsoleConfig>["config"]) {
+  const pending = inflight.get(cacheKey);
+  if (pending) {
+    return pending;
+  }
+  const request = apiBlobRequest(config, proxyPath)
+    .then((blob) => {
+      const objectUrl = URL.createObjectURL(blob);
+      blobUrlCache.set(cacheKey, objectUrl);
+      return objectUrl;
+    })
+    .finally(() => {
+      inflight.delete(cacheKey);
+    });
+  inflight.set(cacheKey, request);
+  return request;
+}
+
 export function AuthenticatedImage({ source, alt, className, loading = "eager" }: AuthenticatedImageProps) {
   const { config } = useConsoleConfig();
   const hostRef = useRef<HTMLSpanElement>(null);
+  const cacheKey = useMemo(() => mediaStableKey(source), [source]);
   const proxyPath = useMemo(() => sdkImageProxyPath(source), [source]);
-  const [visible, setVisible] = useState(loading !== "lazy" || !proxyPath);
-  const [blobUrl, setBlobUrl] = useState("");
-  const [failed, setFailed] = useState(false);
+  const proxyPathRef = useRef(proxyPath);
+  const configRef = useRef(config);
+  proxyPathRef.current = proxyPath;
+  configRef.current = config;
+  const [visible, setVisible] = useState(loading !== "lazy" || !cacheKey);
+  const [blobUrl, setBlobUrl] = useState(() => blobUrlCache.get(cacheKey) || "");
+  const [failed, setFailed] = useState(Boolean(source.trim()) && !proxyPath);
 
   useEffect(() => {
-    setVisible(loading !== "lazy" || !proxyPath);
-    if (loading !== "lazy" || !proxyPath || !hostRef.current || !("IntersectionObserver" in window)) {
+    if (loading !== "lazy" || !cacheKey) {
+      setVisible(true);
+      return;
+    }
+    if (!hostRef.current || !("IntersectionObserver" in window)) {
       setVisible(true);
       return;
     }
@@ -56,33 +124,52 @@ export function AuthenticatedImage({ source, alt, className, loading = "eager" }
     );
     observer.observe(hostRef.current);
     return () => observer.disconnect();
-  }, [loading, proxyPath]);
+  }, [loading, cacheKey]);
 
   useEffect(() => {
-    setBlobUrl("");
-    setFailed(Boolean(source.trim()) && !proxyPath);
-    if (!proxyPath || !visible) {
+    if (!cacheKey) {
+      setBlobUrl("");
+      setFailed(false);
       return;
     }
-    const controller = new AbortController();
-    let objectUrl = "";
-    void apiBlobRequest(config, proxyPath, { signal: controller.signal })
-      .then((blob) => {
-        objectUrl = URL.createObjectURL(blob);
-        setBlobUrl(objectUrl);
+    if (!proxyPathRef.current) {
+      setBlobUrl("");
+      setFailed(true);
+      return;
+    }
+    const cached = blobUrlCache.get(cacheKey);
+    if (cached) {
+      setBlobUrl(cached);
+      setFailed(false);
+      return;
+    }
+    if (!visible) {
+      return;
+    }
+    if (!inflight.has(cacheKey)) {
+      setBlobUrl("");
+    }
+    setFailed(false);
+    let cancelled = false;
+    void loadAuthenticatedBlob(cacheKey, proxyPathRef.current, configRef.current)
+      .then((objectUrl) => {
+        if (!cancelled) {
+          setBlobUrl(objectUrl);
+          setFailed(false);
+        }
       })
       .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
         if (!(error instanceof DOMException && error.name === "AbortError")) {
           setFailed(true);
         }
       });
     return () => {
-      controller.abort();
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-      }
+      cancelled = true;
     };
-  }, [config.apiBaseUrl, config.adminToken, proxyPath, source, visible]);
+  }, [cacheKey, config.adminToken, config.apiBaseUrl, visible]);
 
   const displaySource = proxyPath ? blobUrl : "";
   return (
@@ -91,7 +178,13 @@ export function AuthenticatedImage({ source, alt, className, loading = "eager" }
       className={`authenticated-image-shell ${className}-shell${failed ? " is-error" : ""}`}
     >
       {displaySource ? (
-        <img className={className} src={displaySource} alt={alt} loading={loading} />
+        <img
+          className={className}
+          src={displaySource}
+          alt={alt}
+          loading={loading}
+          onError={() => setFailed(true)}
+        />
       ) : (
         <span className="authenticated-image-placeholder" role={failed ? "alert" : undefined}>
           {failed ? "预览失败" : "加载中"}

--- a/frontend/src/components/AuthenticatedImage.tsx
+++ b/frontend/src/components/AuthenticatedImage.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { apiBlobRequest } from "../lib/api";
-import { useConsoleConfig } from "../state/console-config";
+import {
+  COOKIE_SESSION_MARKER,
+  useConsoleConfig,
+  type ConsoleConfig,
+} from "../state/console-config";
 
 type AuthenticatedImageProps = {
   source: string;
@@ -10,8 +14,22 @@ type AuthenticatedImageProps = {
   loading?: "eager" | "lazy";
 };
 
-const blobUrlCache = new Map<string, string>();
-const inflight = new Map<string, Promise<string>>();
+type CachedBlob = {
+  objectUrl: string;
+  expiresAtMs: number;
+};
+
+type DisplayedBlob = CachedBlob & {
+  cacheKey: string;
+};
+
+const MAX_BLOB_CACHE_ENTRIES = 64;
+const MAX_BLOB_CACHE_AGE_MS = 60_000;
+const blobUrlCache = new Map<string, CachedBlob>();
+const inflight = new Map<string, Promise<CachedBlob>>();
+let cacheGeneration = 0;
+let cookieSessionConsumers = 0;
+let cookieSessionCleanupVersion = 0;
 
 function mediaIdFromLocator(source: string) {
   const value = source.trim();
@@ -40,6 +58,20 @@ function decodeMid1Payload(mediaId: string): Record<string, unknown> | null {
   }
 }
 
+function mediaExpiryMs(source: string) {
+  const mediaId = mediaIdFromLocator(source);
+  const payload = mediaId ? decodeMid1Payload(mediaId) : null;
+  const expiresAtSeconds = payload?.e;
+  if (
+    typeof expiresAtSeconds !== "number" ||
+    !Number.isSafeInteger(expiresAtSeconds) ||
+    expiresAtSeconds <= 0
+  ) {
+    return null;
+  }
+  return expiresAtSeconds * 1000;
+}
+
 export function mediaStableKey(source: string) {
   const trimmed = source.trim();
   const mediaId = mediaIdFromLocator(trimmed);
@@ -56,6 +88,28 @@ export function mediaStableKey(source: string) {
   return `mid1:${tenant}:${kind}:${role}:${payload.l}`;
 }
 
+function normalizedApiBaseUrl(value: string) {
+  const trimmed = value.trim();
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return trimmed;
+  }
+}
+
+function scopedCacheKey(stableKey: string, config: ConsoleConfig) {
+  if (!stableKey) {
+    return "";
+  }
+  return JSON.stringify([
+    normalizedApiBaseUrl(config.apiBaseUrl),
+    config.adminToken.trim(),
+    config.tenantId.trim(),
+    config.userId.trim(),
+    stableKey,
+  ]);
+}
+
 export function sdkImageProxyPath(source: string) {
   const mediaId = mediaIdFromLocator(source);
   if (!mediaId) {
@@ -68,24 +122,92 @@ export function sdkImageDisplayPath(source: string) {
   return mediaIdFromLocator(source) ? "受保护媒体" : source;
 }
 
+function revokeObjectUrl(objectUrl: string) {
+  URL.revokeObjectURL(objectUrl);
+}
+
+function removeCachedBlob(cacheKey: string, expectedObjectUrl?: string) {
+  const cached = blobUrlCache.get(cacheKey);
+  if (!cached || (expectedObjectUrl && cached.objectUrl !== expectedObjectUrl)) {
+    return;
+  }
+  blobUrlCache.delete(cacheKey);
+  revokeObjectUrl(cached.objectUrl);
+}
+
+function getCachedBlob(cacheKey: string, source: string) {
+  const cached = blobUrlCache.get(cacheKey);
+  if (!cached) {
+    return null;
+  }
+  const sourceExpiryMs = mediaExpiryMs(source);
+  if (
+    cached.expiresAtMs <= Date.now() ||
+    (sourceExpiryMs !== null && sourceExpiryMs <= Date.now())
+  ) {
+    removeCachedBlob(cacheKey, cached.objectUrl);
+    return null;
+  }
+  // Map insertion order is the LRU order. A hit promotes the entry.
+  blobUrlCache.delete(cacheKey);
+  blobUrlCache.set(cacheKey, cached);
+  return cached;
+}
+
+function cacheBlob(cacheKey: string, cached: CachedBlob) {
+  removeCachedBlob(cacheKey);
+  blobUrlCache.set(cacheKey, cached);
+  while (blobUrlCache.size > MAX_BLOB_CACHE_ENTRIES) {
+    const oldestKey = blobUrlCache.keys().next().value as string | undefined;
+    if (!oldestKey) {
+      break;
+    }
+    removeCachedBlob(oldestKey);
+  }
+}
+
 export function resetAuthenticatedImageCache() {
+  cacheGeneration += 1;
+  for (const cached of blobUrlCache.values()) {
+    revokeObjectUrl(cached.objectUrl);
+  }
   blobUrlCache.clear();
   inflight.clear();
 }
 
-function loadAuthenticatedBlob(cacheKey: string, proxyPath: string, config: ReturnType<typeof useConsoleConfig>["config"]) {
+function loadAuthenticatedBlob(
+  cacheKey: string,
+  proxyPath: string,
+  source: string,
+  config: ConsoleConfig,
+) {
   const pending = inflight.get(cacheKey);
   if (pending) {
     return pending;
   }
+  const generation = cacheGeneration;
   const request = apiBlobRequest(config, proxyPath)
     .then((blob) => {
-      const objectUrl = URL.createObjectURL(blob);
-      blobUrlCache.set(cacheKey, objectUrl);
-      return objectUrl;
+      if (generation !== cacheGeneration) {
+        throw new DOMException("Authenticated image cache was reset", "AbortError");
+      }
+      const now = Date.now();
+      const signedExpiryMs = mediaExpiryMs(source);
+      const expiresAtMs = Math.min(
+        now + MAX_BLOB_CACHE_AGE_MS,
+        signedExpiryMs ?? Number.POSITIVE_INFINITY,
+      );
+      if (expiresAtMs <= now) {
+        throw new Error("Signed media identifier has expired");
+      }
+      const cached = { objectUrl: URL.createObjectURL(blob), expiresAtMs };
+      cacheBlob(cacheKey, cached);
+      return cached;
     })
     .finally(() => {
-      inflight.delete(cacheKey);
+      if (inflight.get(cacheKey) === request) {
+        inflight.delete(cacheKey);
+      }
     });
   inflight.set(cacheKey, request);
   return request;
@@ -94,18 +216,38 @@ function loadAuthenticatedBlob(cacheKey: string, proxyPath: string, config: Retu
 export function AuthenticatedImage({ source, alt, className, loading = "eager" }: AuthenticatedImageProps) {
   const { config } = useConsoleConfig();
   const hostRef = useRef<HTMLSpanElement>(null);
-  const cacheKey = useMemo(() => mediaStableKey(source), [source]);
+  const stableKey = useMemo(() => mediaStableKey(source), [source]);
+  const cacheKey = useMemo(
+    () => scopedCacheKey(stableKey, config),
+    [stableKey, config.adminToken, config.apiBaseUrl, config.tenantId, config.userId],
+  );
   const proxyPath = useMemo(() => sdkImageProxyPath(source), [source]);
-  const proxyPathRef = useRef(proxyPath);
-  const configRef = useRef(config);
-  proxyPathRef.current = proxyPath;
-  configRef.current = config;
-  const [visible, setVisible] = useState(loading !== "lazy" || !cacheKey);
-  const [blobUrl, setBlobUrl] = useState(() => blobUrlCache.get(cacheKey) || "");
-  const [failed, setFailed] = useState(Boolean(source.trim()) && !proxyPath);
+  const [visible, setVisible] = useState(loading !== "lazy" || !stableKey);
+  const [displayedBlob, setDisplayedBlob] = useState<DisplayedBlob | null>(null);
+  const [failedCacheKey, setFailedCacheKey] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
-    if (loading !== "lazy" || !cacheKey) {
+    if (!cacheKey || config.adminToken.trim() !== COOKIE_SESSION_MARKER) {
+      return;
+    }
+    cookieSessionConsumers += 1;
+    cookieSessionCleanupVersion += 1;
+    return () => {
+      cookieSessionConsumers -= 1;
+      const cleanupVersion = ++cookieSessionCleanupVersion;
+      queueMicrotask(() => {
+        if (cookieSessionConsumers === 0 && cleanupVersion === cookieSessionCleanupVersion) {
+          // The cookie is HttpOnly, so its administrator identity is intentionally opaque.
+          // Do not let cache entries survive the last image consumer (for example, logout).
+          resetAuthenticatedImageCache();
+        }
+      });
+    };
+  }, [cacheKey, config.adminToken]);
+
+  useEffect(() => {
+    if (loading !== "lazy" || !stableKey) {
       setVisible(true);
       return;
     }
@@ -124,38 +266,36 @@ export function AuthenticatedImage({ source, alt, className, loading = "eager" }
     );
     observer.observe(hostRef.current);
     return () => observer.disconnect();
-  }, [loading, cacheKey]);
+  }, [loading, stableKey]);
 
   useEffect(() => {
     if (!cacheKey) {
-      setBlobUrl("");
-      setFailed(false);
+      setDisplayedBlob(null);
+      setFailedCacheKey(null);
       return;
     }
-    if (!proxyPathRef.current) {
-      setBlobUrl("");
-      setFailed(true);
+    if (!proxyPath) {
+      setDisplayedBlob(null);
+      setFailedCacheKey(cacheKey);
       return;
     }
-    const cached = blobUrlCache.get(cacheKey);
+    const cached = getCachedBlob(cacheKey, source);
     if (cached) {
-      setBlobUrl(cached);
-      setFailed(false);
+      setDisplayedBlob({ cacheKey, ...cached });
+      setFailedCacheKey(null);
       return;
     }
     if (!visible) {
       return;
     }
-    if (!inflight.has(cacheKey)) {
-      setBlobUrl("");
-    }
-    setFailed(false);
+    setDisplayedBlob(null);
+    setFailedCacheKey(null);
     let cancelled = false;
-    void loadAuthenticatedBlob(cacheKey, proxyPathRef.current, configRef.current)
-      .then((objectUrl) => {
+    void loadAuthenticatedBlob(cacheKey, proxyPath, source, config)
+      .then((loaded) => {
         if (!cancelled) {
-          setBlobUrl(objectUrl);
-          setFailed(false);
+          setDisplayedBlob({ cacheKey, ...loaded });
+          setFailedCacheKey(null);
         }
       })
       .catch((error: unknown) => {
@@ -163,15 +303,39 @@ export function AuthenticatedImage({ source, alt, className, loading = "eager" }
           return;
         }
         if (!(error instanceof DOMException && error.name === "AbortError")) {
-          setFailed(true);
+          setDisplayedBlob(null);
+          setFailedCacheKey(cacheKey);
         }
       });
     return () => {
       cancelled = true;
     };
-  }, [cacheKey, config.adminToken, config.apiBaseUrl, visible]);
+  }, [cacheKey, proxyPath, reloadKey, source, visible]);
 
-  const displaySource = proxyPath ? blobUrl : "";
+  const currentBlob = displayedBlob?.cacheKey === cacheKey ? displayedBlob : null;
+
+  useEffect(() => {
+    if (!currentBlob) {
+      return;
+    }
+    const expire = () => {
+      removeCachedBlob(cacheKey, currentBlob.objectUrl);
+      setDisplayedBlob((current) =>
+        current?.cacheKey === cacheKey && current.objectUrl === currentBlob.objectUrl ? null : current,
+      );
+      setReloadKey((current) => current + 1);
+    };
+    const remainingMs = currentBlob.expiresAtMs - Date.now();
+    if (remainingMs <= 0) {
+      expire();
+      return;
+    }
+    const timer = window.setTimeout(expire, remainingMs);
+    return () => window.clearTimeout(timer);
+  }, [cacheKey, currentBlob]);
+
+  const failed = failedCacheKey === cacheKey;
+  const displaySource = proxyPath && !failed ? currentBlob?.objectUrl || "" : "";
   return (
     <span
       ref={hostRef}
@@ -183,7 +347,11 @@ export function AuthenticatedImage({ source, alt, className, loading = "eager" }
           src={displaySource}
           alt={alt}
           loading={loading}
-          onError={() => setFailed(true)}
+          onError={() => {
+            removeCachedBlob(cacheKey, displaySource);
+            setDisplayedBlob(null);
+            setFailedCacheKey(cacheKey);
+          }}
         />
       ) : (
         <span className="authenticated-image-placeholder" role={failed ? "alert" : undefined}>

--- a/frontend/src/pages/MessageQueuesPage.test.tsx
+++ b/frontend/src/pages/MessageQueuesPage.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../components/AuthenticatedImage", () => ({
     alt: string;
     className: string;
   }) => <img src={source} alt={alt} className={className} data-media-source={source} />,
+  mediaStableKey: (source: string) => source,
   sdkImageProxyPath: (source: string) =>
     source.startsWith("media:") ? `/plugins/wxbot/admin/images/${source.slice(6)}` : "",
   sdkImageDisplayPath: (source: string) =>

--- a/frontend/src/pages/MessageQueuesPage.tsx
+++ b/frontend/src/pages/MessageQueuesPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import {
   AuthenticatedImage,
+  mediaStableKey,
   sdkImageDisplayPath,
   sdkImageProxyPath,
 } from "../components/AuthenticatedImage";
@@ -167,6 +168,10 @@ function queueImage(
     previewUrl: previewUrl || thumbnailUrl,
     thumbnailUrl: thumbnailUrl || previewUrl,
   };
+}
+
+function queueImageKey(image: QueueImage) {
+  return `${image.label}:${mediaStableKey(image.previewUrl)}:${mediaStableKey(image.thumbnailUrl)}`;
 }
 
 function quoteRecords(payload: Record<string, unknown>) {
@@ -370,7 +375,7 @@ function extractQueueImages(payload: Record<string, unknown>) {
   const deduped: QueueImage[] = [];
   const seen = new Set<string>();
   for (const image of images) {
-    const key = `${image.label}:${image.previewUrl}:${image.thumbnailUrl}`;
+    const key = queueImageKey(image);
     if ((!image.previewUrl && !image.thumbnailUrl) || seen.has(key)) {
       continue;
     }
@@ -880,7 +885,7 @@ export function MessageQueuesPage() {
                     {!!images.length && (
                       <span className="queue-message-card-media" aria-label={`${images.length} 张关联图片`}>
                         {images.slice(0, 2).map((image) => (
-                          <span className="queue-image-thumb-wrap" key={`${image.label}:${image.previewUrl}:${image.thumbnailUrl}`}>
+                          <span className="queue-image-thumb-wrap" key={queueImageKey(image)}>
                             <AuthenticatedImage
                               className="queue-image-thumb"
                               source={image.thumbnailUrl || image.previewUrl}
@@ -937,7 +942,7 @@ export function MessageQueuesPage() {
                 {!!selectedDirectImages.length && (
                   <div className="queue-image-preview-wrap">
                     {selectedDirectImages.map((image) => (
-                      <div className="queue-image-preview-item" key={`${image.label}:${image.previewUrl}`}>
+                      <div className="queue-image-preview-item" key={queueImageKey(image)}>
                         <div className="queue-image-preview-title">消息图片</div>
                         <AuthenticatedImage
                           className="queue-image-preview"
@@ -969,7 +974,7 @@ export function MessageQueuesPage() {
                       <p className="muted-copy mono">原消息标识 {selectedQuote.messageId}</p>
                     )}
                     {selectedQuoteImages.map((image) => (
-                      <div className="queue-image-preview-item" key={`${image.label}:${image.previewUrl}`}>
+                      <div className="queue-image-preview-item" key={queueImageKey(image)}>
                         <div className="queue-image-preview-title">引用原图</div>
                         <AuthenticatedImage
                           className="queue-image-preview"


### PR DESCRIPTION
## Summary
- derive stable media keys so signed-ID rotation does not refetch or remount queue images
- coalesce concurrent protected-image requests and reuse valid blob URLs
- isolate cache entries by API endpoint, tenant, user, and admin/session identity
- bound the cache to 64 entries and revoke blob URLs on expiry, eviction, reset, or image failure
- periodically revalidate signed media instead of bypassing revocation indefinitely
- render a failure placeholder when browser image decoding fails

## Verification
- 19 targeted frontend tests passed
- TypeScript typecheck passed

## Stack
This PR is based on `codex/console-portrait-refresh` (PR #6) because the queue page was restyled there. After #6 merges, this PR can be retargeted to `main`.